### PR TITLE
Include IDE specific files in gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,21 @@ build
 dist
 *.egg-info
 *.pyc
+
+# IDE Specific files
+### Pycharm IDE - Jetbrains
+.idea/*
+
+### PyDev IDE - Eclipse
+.metadata
+tmp/
+*.tmp
+*.bak
+local.properties
+.settings/
+.loadpath
+*.project
+*.pydevproject
+
+### YouCompleteMe - VIM plugin
+.ycm_extra_conf.py


### PR DESCRIPTION
As described in #55, the necessary files have been included in .gitignore :

* Pycharm IDE - Jetbrains.
* PyDev IDE - Eclipse.
* YouCompleteMe plugin - VIM.