### PR TITLE
Optimize results sorting

### DIFF
--- a/pytest_html/resources/main.js
+++ b/pytest_html/resources/main.js
@@ -82,11 +82,18 @@ function sort_table(clicked, key_func) {
     var rows = find_all('.results-table-row');
     var reversed = !clicked.classList.contains('asc');
     var sorted_rows = sort(rows, key_func, reversed);
-
-    var parent = document.getElementById('results-table');
+    /* Whole table is removed here because browsers acts much slower
+     * when appending existing elements.
+     */
+    var thead = document.getElementById("results-table-head");
+    document.getElementById('results-table').remove();
+    var parent = document.createElement("table");
+    parent.id = "results-table";
+    parent.appendChild(thead);
     sorted_rows.forEach(function(elem) {
         parent.appendChild(elem);
     });
+    document.getElementsByTagName("BODY")[0].appendChild(parent);
 }
 
 function sort(items, key_func, reversed) {


### PR DESCRIPTION
Clean up table before calling appendElement for each element.

Actually table is completely removed and created a new one. This is the
fastest way to have clean table.

This approach is ~10% faster in chromium and ~400% faster in Firefox.

Here is sample report pages:

With this patch: https://r-ci.tk/stuff/pytest.html
Without this patch: https://r-ci.tk/stuff/pytest-old.html

Closes #59 