### PR TITLE
Fix for issue84 - Marking Test XPassed as opposed to XFAILED

### DIFF
--- a/pytest_html/plugin.py
+++ b/pytest_html/plugin.py
@@ -255,8 +255,8 @@ class HTMLReport(object):
         if report.when == "call":
             if hasattr(report, "wasxfail"):
                 # pytest < 3.0 marked xpasses as failures
-                self.xpassed += 1
-                self._appendrow('XPassed', report)
+                self.xfailed += 1
+                self._appendrow('XFailed', report)
             else:
                 self.failed += 1
                 self._appendrow('Failed', report)


### PR DESCRIPTION
When a Test is Failed and it is an expected failure (ie wasxfail is set) then it should be marked as XFailed and not XPassed.
XFailed - Expected Failed