### PR TITLE
Add support for jpg and svg

### DIFF
--- a/pytest_html/extras.py
+++ b/pytest_html/extras.py
@@ -8,9 +8,13 @@ FORMAT_JSON = 'json'
 FORMAT_TEXT = 'text'
 FORMAT_URL = 'url'
 
+TYPE_JPG = ('image/jpeg', 'jpg')
+TYPE_PNG = ('image/png', 'png')
+TYPE_SVG = ('image/svg+xml', 'svg')
 
-def extra(content, format, name=None):
-    return {'name': name, 'format': format, 'content': content}
+
+def extra(content, format, name=None, type=None):
+    return {'name': name, 'format': format, 'content': content, 'type': type}
 
 
 def html(content):
@@ -18,7 +22,16 @@ def html(content):
 
 
 def image(content, name='Image'):
-    return extra(content, FORMAT_IMAGE, name)
+    return imagePNG(content=content, name=name)
+
+def imagePNG(content, name='Image'):
+    return extra(content, FORMAT_IMAGE, name, type=TYPE_PNG)
+
+def imageJPG(content, name='Image'):
+    return extra(content, FORMAT_IMAGE, name, type=TYPE_JPG)
+
+def imageSVG(content, name='Image'):
+    return extra(content, FORMAT_IMAGE, name, type=TYPE_SVG)
 
 
 def json(content, name='JSON'):

--- a/pytest_html/extras.py
+++ b/pytest_html/extras.py
@@ -1,6 +1,8 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+import binascii
+import base64
 
 FORMAT_HTML = 'html'
 FORMAT_IMAGE = 'image'
@@ -8,13 +10,10 @@ FORMAT_JSON = 'json'
 FORMAT_TEXT = 'text'
 FORMAT_URL = 'url'
 
-TYPE_JPG = ('image/jpeg', 'jpg')
-TYPE_PNG = ('image/png', 'png')
-TYPE_SVG = ('image/svg+xml', 'svg')
 
-
-def extra(content, format, name=None, type=None):
-    return {'name': name, 'format': format, 'content': content, 'type': type}
+def extra(content, format, name=None, mime_type='image/png', extension='png'):
+    return {'name': name, 'format': format, 'content': content,
+            'mime_type': mime_type, 'extension': extension}
 
 
 def html(content):
@@ -22,19 +21,19 @@ def html(content):
 
 
 def image(content, name='Image'):
-    return imagePNG(content=content, name=name)
+    return png(content=content, name=name)
 
 
-def imagePNG(content, name='Image'):
-    return extra(content, FORMAT_IMAGE, name, type=TYPE_PNG)
+def png(content, name='Image'):
+    return extra(content, FORMAT_IMAGE, name, mime_type='image/png', extension='png')
 
 
-def imageJPG(content, name='Image'):
-    return extra(content, FORMAT_IMAGE, name, type=TYPE_JPG)
+def jpg(content, name='Image'):
+    return extra(content, FORMAT_IMAGE, name, mime_type='image/jpeg', extension='jpg')
 
 
-def imageSVG(content, name='Image'):
-    return extra(content, FORMAT_IMAGE, name, type=TYPE_SVG)
+def svg(content, name='Image'):
+    return extra(content, FORMAT_IMAGE, name, mime_type='image/svg+xml', extension='svg')
 
 
 def json(content, name='JSON'):

--- a/pytest_html/extras.py
+++ b/pytest_html/extras.py
@@ -9,7 +9,7 @@ FORMAT_TEXT = 'text'
 FORMAT_URL = 'url'
 
 
-def extra(content, format, name=None, mime_type='image/png', extension='png'):
+def extra(content, format, name=None, mime_type=None, extension=None):
     return {'name': name, 'format': format, 'content': content,
             'mime_type': mime_type, 'extension': extension}
 
@@ -18,27 +18,24 @@ def html(content):
     return extra(content, FORMAT_HTML)
 
 
-def image(content, name='Image'):
-    return png(content=content, name=name)
+def image(content, name='Image', mime_type='image/png', extension='png'):
+    return extra(content, FORMAT_IMAGE, name, mime_type, extension)
 
 
 def png(content, name='Image'):
-    return extra(content, FORMAT_IMAGE, name,
-                 mime_type='image/png', extension='png')
+    return image(content, name, mime_type='image/png', extension='png')
 
 
 def jpg(content, name='Image'):
-    return extra(content, FORMAT_IMAGE, name,
-                 mime_type='image/jpeg', extension='jpg')
+    return image(content, name, mime_type='image/jpeg', extension='jpg')
 
 
 def svg(content, name='Image'):
-    return extra(content, FORMAT_IMAGE, name,
-                 mime_type='image/svg+xml', extension='svg')
+    return image(content, name, mime_type='image/svg+xml', extension='svg')
 
 
 def json(content, name='JSON'):
-    return extra(content, FORMAT_JSON, name)
+    return extra(content, FORMAT_JSON, name, 'application/json', 'json')
 
 
 def text(content, name='Text'):

--- a/pytest_html/extras.py
+++ b/pytest_html/extras.py
@@ -24,11 +24,14 @@ def html(content):
 def image(content, name='Image'):
     return imagePNG(content=content, name=name)
 
+
 def imagePNG(content, name='Image'):
     return extra(content, FORMAT_IMAGE, name, type=TYPE_PNG)
 
+
 def imageJPG(content, name='Image'):
     return extra(content, FORMAT_IMAGE, name, type=TYPE_JPG)
+
 
 def imageSVG(content, name='Image'):
     return extra(content, FORMAT_IMAGE, name, type=TYPE_SVG)

--- a/pytest_html/extras.py
+++ b/pytest_html/extras.py
@@ -39,7 +39,7 @@ def json(content, name='JSON'):
 
 
 def text(content, name='Text'):
-    return extra(content, FORMAT_TEXT, name)
+    return extra(content, FORMAT_TEXT, name, 'text/plain', 'txt')
 
 
 def url(content, name='URL'):

--- a/pytest_html/extras.py
+++ b/pytest_html/extras.py
@@ -1,8 +1,6 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-import binascii
-import base64
 
 FORMAT_HTML = 'html'
 FORMAT_IMAGE = 'image'
@@ -25,15 +23,18 @@ def image(content, name='Image'):
 
 
 def png(content, name='Image'):
-    return extra(content, FORMAT_IMAGE, name, mime_type='image/png', extension='png')
+    return extra(content, FORMAT_IMAGE, name,
+                 mime_type='image/png', extension='png')
 
 
 def jpg(content, name='Image'):
-    return extra(content, FORMAT_IMAGE, name, mime_type='image/jpeg', extension='jpg')
+    return extra(content, FORMAT_IMAGE, name,
+                 mime_type='image/jpeg', extension='jpg')
 
 
 def svg(content, name='Image'):
-    return extra(content, FORMAT_IMAGE, name, mime_type='image/svg+xml', extension='svg')
+    return extra(content, FORMAT_IMAGE, name,
+                 mime_type='image/svg+xml', extension='svg')
 
 
 def json(content, name='JSON'):

--- a/pytest_html/plugin.py
+++ b/pytest_html/plugin.py
@@ -383,7 +383,7 @@ class HTMLReport(object):
                     colspan='5')],
                     id='not-found-message', hidden='true'),
             id='results-table-head'),
-                self.test_logs],  id='results-table')]
+                self.test_logs], id='results-table')]
 
         main_js = pkg_resources.resource_string(
             __name__, os.path.join('resources', 'main.js'))

--- a/pytest_html/plugin.py
+++ b/pytest_html/plugin.py
@@ -159,8 +159,9 @@ class HTMLReport(object):
             href = None
             if extra.get('format') == extras.FORMAT_IMAGE:
                 if self.self_contained:
-                    src = 'data:image/png;base64,{0}'.format(
-                            extra.get('content'))
+                    src = 'data:{0};base64,{1}'.format(
+                        extra.get('type')[0],
+                        extra.get('content'))
                     self.additional_html.append(html.div(
                         html.img(src=src), class_='image'))
                 else:
@@ -170,7 +171,7 @@ class HTMLReport(object):
                     else:
                         content = b64decode(content)
                     href = src = self.create_asset(
-                        content, extra_index, test_index, 'png', 'wb')
+                        content, extra_index, test_index, extra.get('type')[1], 'wb')
                     self.additional_html.append(html.div(
                         html.a(html.img(src=src), href=href),
                         class_='image'))

--- a/pytest_html/plugin.py
+++ b/pytest_html/plugin.py
@@ -197,7 +197,8 @@ class HTMLReport(object):
                     href = data_uri(content)
                 else:
                     href = self.create_asset(content, extra_index,
-                                             test_index, 'txt')
+                                             test_index,
+                                             extra.get('extension'))
 
             elif extra.get('format') == extras.FORMAT_URL:
                 href = extra.get('content')

--- a/pytest_html/plugin.py
+++ b/pytest_html/plugin.py
@@ -184,10 +184,10 @@ class HTMLReport(object):
             elif extra.get('format') == extras.FORMAT_JSON:
                 content = json.dumps(extra.get('content'))
                 if self.self_contained:
-                    href = data_uri(content, mime_type='application/json')
+                    href = data_uri(content, mime_type=extra.get('mime_type'))
                 else:
                     href = self.create_asset(content, extra_index,
-                                             test_index, 'json')
+                                             test_index, extra.get('extension'))
 
             elif extra.get('format') == extras.FORMAT_TEXT:
                 content = extra.get('content')

--- a/pytest_html/plugin.py
+++ b/pytest_html/plugin.py
@@ -160,7 +160,7 @@ class HTMLReport(object):
             if extra.get('format') == extras.FORMAT_IMAGE:
                 if self.self_contained:
                     src = 'data:{0};base64,{1}'.format(
-                        extra.get('type')[0],
+                        extra.get('mime_type'),
                         extra.get('content'))
                     self.additional_html.append(html.div(
                         html.img(src=src), class_='image'))
@@ -172,7 +172,7 @@ class HTMLReport(object):
                         content = b64decode(content)
                     href = src = self.create_asset(
                         content, extra_index, test_index,
-                        extra.get('type')[1], 'wb')
+                        extra.get('extension'), 'wb')
                     self.additional_html.append(html.div(
                         html.a(html.img(src=src), href=href),
                         class_='image'))

--- a/pytest_html/plugin.py
+++ b/pytest_html/plugin.py
@@ -184,10 +184,12 @@ class HTMLReport(object):
             elif extra.get('format') == extras.FORMAT_JSON:
                 content = json.dumps(extra.get('content'))
                 if self.self_contained:
-                    href = data_uri(content, mime_type=extra.get('mime_type'))
+                    href = data_uri(content,
+                                    mime_type=extra.get('mime_type'))
                 else:
                     href = self.create_asset(content, extra_index,
-                                             test_index, extra.get('extension'))
+                                             test_index,
+                                             extra.get('extension'))
 
             elif extra.get('format') == extras.FORMAT_TEXT:
                 content = extra.get('content')

--- a/pytest_html/plugin.py
+++ b/pytest_html/plugin.py
@@ -171,7 +171,8 @@ class HTMLReport(object):
                     else:
                         content = b64decode(content)
                     href = src = self.create_asset(
-                        content, extra_index, test_index, extra.get('type')[1], 'wb')
+                        content, extra_index, test_index,
+                        extra.get('type')[1], 'wb')
                     self.additional_html.append(html.div(
                         html.a(html.img(src=src), href=href),
                         class_='image'))

--- a/testing/test_pytest_html.py
+++ b/testing/test_pytest_html.py
@@ -305,7 +305,7 @@ class TestHTML:
             content)
         assert link in html
 
-    def test_extra_image(self, testdir):
+    def test_extra_png_image(self, testdir):
         content = str(random.random())
         testdir.makeconftest("""
             import pytest
@@ -321,6 +321,42 @@ class TestHTML:
         result, html = run(testdir, 'report.html', '--self-contained-html')
         assert result.ret == 0
         src = 'data:image/png;base64,{0}'.format(content)
+        assert '<img src="{0}"/>'.format(src) in html
+
+    def test_extra_jpg_image(self, testdir):
+        content = str(random.random())
+        testdir.makeconftest("""
+            import pytest
+            @pytest.mark.hookwrapper
+            def pytest_runtest_makereport(item, call):
+                outcome = yield
+                report = outcome.get_result()
+                if report.when == 'call':
+                    from pytest_html import extras
+                    report.extra = [extras.jpg('{0}')]
+        """.format(content))
+        testdir.makepyfile('def test_pass(): pass')
+        result, html = run(testdir, 'report.html', '--self-contained-html')
+        assert result.ret == 0
+        src = 'data:image/jpeg;base64,{0}'.format(content)
+        assert '<img src="{0}"/>'.format(src) in html
+
+    def test_extra_svg_image(self, testdir):
+        content = str(random.random())
+        testdir.makeconftest("""
+            import pytest
+            @pytest.mark.hookwrapper
+            def pytest_runtest_makereport(item, call):
+                outcome = yield
+                report = outcome.get_result()
+                if report.when == 'call':
+                    from pytest_html import extras
+                    report.extra = [extras.svg('{0}')]
+        """.format(content))
+        testdir.makepyfile('def test_pass(): pass')
+        result, html = run(testdir, 'report.html', '--self-contained-html')
+        assert result.ret == 0
+        src = 'data:image/svg+xml;base64,{0}'.format(content)
         assert '<img src="{0}"/>'.format(src) in html
 
     @pytest.mark.parametrize('file_extension,file_type',

--- a/testing/test_pytest_html.py
+++ b/testing/test_pytest_html.py
@@ -328,11 +328,15 @@ class TestHTML:
         src = 'data:{0};base64,{1}'.format(mime_type, content)
         assert '<img src="{0}"/>'.format(src) in html
 
-    @pytest.mark.parametrize('file_extension,file_type',
-                             [('png', 'image'),
-                              ('json', 'json'),
-                              ('txt', 'text')])
-    def test_extra_separated(self, testdir, file_extension, file_type):
+    @pytest.mark.parametrize('file_extension, extra_type, file_type',
+                             [('png', 'image', 'image'),
+                              ('png', 'png', 'image'),
+                              ('svg', 'svg', 'image'),
+                              ('jpg', 'jpg', 'image'),
+                              ('json', 'json', 'json'),
+                              ('txt', 'text', 'text')])
+    def test_extra_separated(self, testdir, file_extension,
+                             extra_type, file_type):
         content = b64encode(str(random.random())
                             .encode('utf-8')).decode('ascii')
         testdir.makeconftest("""
@@ -344,7 +348,7 @@ class TestHTML:
                 if report.when == 'call':
                     from pytest_html import extras
                     report.extra = [extras.{0}('{1}')]
-        """.format(file_type, content))
+        """.format(extra_type, content))
         testdir.makepyfile('def test_pass(): pass')
         result, html = run(testdir)
         hash_key = ('test_extra_separated.py::'
@@ -360,11 +364,15 @@ class TestHTML:
         assert link in html
         assert os.path.exists(src)
 
-    @pytest.mark.parametrize('file_extension,file_type',
-                             [('png', 'image'),
-                              ('json', 'json'),
-                              ('txt', 'text')])
-    def test_extra_separated_rerun(self, testdir, file_extension, file_type):
+    @pytest.mark.parametrize('file_extension, extra_type, file_type',
+                             [('png', 'png', 'image'),
+                              ('png', 'image', 'image'),
+                              ('svg', 'svg', 'image'),
+                              ('jpg', 'jpg', 'image'),
+                              ('json', 'json', 'json'),
+                              ('txt', 'text', 'text')])
+    def test_extra_separated_rerun(self, testdir, file_extension,
+                                   extra_type, file_type):
         content = b64encode(str(random.random())
                             .encode('utf-8')).decode('ascii')
         testdir.makeconftest("""
@@ -376,7 +384,7 @@ class TestHTML:
                 if report.when == 'call':
                     from pytest_html import extras
                     report.extra = [extras.{0}('{1}')]
-        """.format(file_type, content))
+        """.format(extra_type, content))
         testdir.makepyfile("""
             import pytest
             @pytest.mark.flaky(reruns=2)


### PR DESCRIPTION
It would be nice if the report support JPEG and SVG images. At the moment it only supports PNG. And if the image is not a png the browser can't display the image properly.
