### PR TITLE
Pull request to pytest-dev/master from fredpalmer/feature/multiple-images-support

### DIFF
--- a/pytest_html/resources/style.css
+++ b/pytest_html/resources/style.css
@@ -90,14 +90,14 @@ span.error, span.failed, span.xpassed, .error .col-result, .failed .col-result, 
 	color: black;
 	display: block;
 	font-family: "Courier New", Courier, monospace;
-	height: 230px;
-	overflow-y: scroll;
+	height: 100%;
 	padding: 5px;
 	white-space: pre-wrap
 }
 div.image {
 	border: 1px solid #e6e6e6;
 	float: right;
+	clear: right;
 	height: 240px;
 	margin-left: 5px;
 	overflow: hidden;

--- a/pytest_html/resources/style.css
+++ b/pytest_html/resources/style.css
@@ -80,6 +80,10 @@ span.error, span.failed, span.xpassed, .error .col-result, .failed .col-result, 
 /*------------------
  * 2. Extra
  *------------------*/
+.col-links a {
+	float: right;
+	clear: right;
+}
 
 .log:only-child {
 	height: inherit


### PR DESCRIPTION
## Summary
> Provide Better Support for Multiple Images

## Example
> Example test with multiple images.  Images are now stacked.  Additionally the _hard-coded_ height has been removed from the `log` section as well.

<img width="1418" alt="test_report" src="https://cloud.githubusercontent.com/assets/32422/22350508/b4c79b88-e3d9-11e6-8b63-de37079141dc.png">


