### PR TITLE
Use latest dependencies when running tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,10 @@ matrix:
     env: TOXENV=flake8
   - language: python
     python: 2.7
+    env: TOXENV=py27
   - language: python
     python: 2.7
-    env: TOXENV=ansi2html
+    env: TOXENV=py27-ansi2html
   - language: python
     python: 3.6
     env: TOXENV=flake8
@@ -21,24 +22,21 @@ matrix:
     env: TOXENV=py36
   - language: python
     python: 3.6
-    env: TOXENV=ansi2html
+    env: TOXENV=py36-ansi2html
   - language: python
     python: pypy
+    env: TOXENV=pypy
   - language: python
     python: pypy
-    env: TOXENV=ansi2html
+    env: TOXENV=pypy-ansi2html
   - language: python
     python: pypy3
+    env: TOXENV=pypy3
   - language: python
     python: pypy3
-    env: TOXENV=ansi2html
-  - language: python
-    python: nightly
-  - language: python
-    python: nightly
-    env: TOXENV=ansi2html
+    env: TOXENV=pypy3-ansi2html
 install:
-- pip install tox-travis
+- pip install tox
 script:
 - tox
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,52 +10,33 @@ matrix:
     env: TOXENV=flake8
   - language: python
     python: 2.7
-    env: TOXENV=pytest29
   - language: python
     python: 2.7
-    env: TOXENV=pytest30
-  - language: python
-    python: 2.7
-    env: TOXENV=pytest30-ansi2html
+    env: TOXENV=ansi2html
   - language: python
     python: 3.6
     env: TOXENV=flake8
   - language: python
     python: 3.6
-    env: TOXENV=pytest29
+    env: TOXENV=py36
   - language: python
     python: 3.6
-    env: TOXENV=pytest30
-  - language: python
-    python: 3.6
-    env: TOXENV=pytest30-ansi2html
+    env: TOXENV=ansi2html
   - language: python
     python: pypy
-    env: TOXENV=pytest29
   - language: python
     python: pypy
-    env: TOXENV=pytest30
-  - language: python
-    python: pypy
-    env: TOXENV=pytest30-ansi2html
+    env: TOXENV=ansi2html
   - language: python
     python: pypy3
-    env: TOXENV=pytest29
   - language: python
     python: pypy3
-    env: TOXENV=pytest30
-  - language: python
-    python: pypy3
-    env: TOXENV=pytest30-ansi2html
+    env: TOXENV=ansi2html
   - language: python
     python: nightly
-    env: TOXENV=pytest29
   - language: python
     python: nightly
-    env: TOXENV=pytest30
-  - language: python
-    python: nightly
-    env: TOXENV=pytest30-ansi2html
+    env: TOXENV=ansi2html
 install:
 - pip install tox-travis
 script:
@@ -70,4 +51,4 @@ deploy:
     tags: true
     repo: pytest-dev/pytest-html
     python: 3.6
-    condition: "$TOXENV = pytest30"
+    condition: "$TOXENV = py36"

--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,6 @@ Requirements
 You will need the following prerequisites in order to use pytest-html:
 
 - Python 2.7, 3.6, PyPy, or PyPy3
-- pytest 2.7 or newer
 
 Installation
 ------------

--- a/tox.ini
+++ b/tox.ini
@@ -4,16 +4,14 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py{27,36,py,py3}-pytest{29,30}{,-ansi2html}, flake8
+envlist = py{27,36,py,py3}{,-ansi2html}, flake8
 
 [testenv]
-commands = py.test -v -r a {posargs}
+commands = pytest -v -r a {posargs}
 deps =
-    pytest29: pytest==2.9.2
-    pytest30: pytest==3.0.6
     pytest-xdist
     pytest-rerunfailures
-    py{27,36,py,py3}-pytest{29,30}-ansi2html: ansi2html==1.2.0
+    py{27,36,py,py3}-ansi2html: ansi2html
 
 [testenv:flake8]
 skip_install = true


### PR DESCRIPTION
Only run tests against the latest versions of all dependencies.