### PR TITLE
Always decode byte in 'extra text' and change ordering according to latest pytest-rerunfailures

### DIFF
--- a/pytest_html/plugin.py
+++ b/pytest_html/plugin.py
@@ -198,6 +198,8 @@ class HTMLReport(object):
 
             elif extra.get('format') == extras.FORMAT_TEXT:
                 content = extra.get('content')
+                if isinstance(content, bytes):
+                    content = content.decode("utf-8")
                 if self.self_contained:
                     href = data_uri(content)
                 else:

--- a/testing/test_pytest_html.py
+++ b/testing/test_pytest_html.py
@@ -238,7 +238,8 @@ class TestHTML:
 
     @pytest.mark.parametrize('content, encoded', [
         ("u'\u0081'", 'woE='),
-        ("'foo'", 'Zm9v')])
+        ("'foo'", 'Zm9v'),
+        ("b'\\xe2\\x80\\x93'", "4oCT")])
     def test_extra_text(self, testdir, content, encoded):
         testdir.makeconftest("""
             import pytest
@@ -325,7 +326,8 @@ class TestHTML:
         src = 'data:{0};base64,{1}'.format(mime_type, content)
         assert '<img src="{0}"/>'.format(src) in html
 
-    @pytest.mark.parametrize('content', [("u'\u0081'"), ("'foo'")])
+    @pytest.mark.parametrize('content', [("u'\u0081'"), ("'foo'"),
+                                         ("b'\\xe2\\x80\\x93'")])
     def test_extra_text_separated(self, testdir, content):
         testdir.makeconftest("""
             import pytest

--- a/testing/test_pytest_html.py
+++ b/testing/test_pytest_html.py
@@ -342,7 +342,7 @@ class TestHTML:
         testdir.makepyfile('def test_pass(): pass')
         result, html = run(testdir)
         hash_key = ('test_extra_text_separated.py::'
-                    'test_pass01').encode('utf-8')
+                    'test_pass00').encode('utf-8')
         hash_generator = hashlib.md5()
         hash_generator.update(hash_key)
         assert result.ret == 0
@@ -372,7 +372,7 @@ class TestHTML:
         testdir.makepyfile('def test_pass(): pass')
         result, html = run(testdir)
         hash_key = ('test_extra_image_separated.py::'
-                    'test_pass01').encode('utf-8')
+                    'test_pass00').encode('utf-8')
         hash_generator = hashlib.md5()
         hash_generator.update(hash_key)
         assert result.ret == 0


### PR DESCRIPTION
I got decoding issue when create extra "text".  Extra "text" contains em-dash "—" as bytes "\xe2\x80\x94".

> INTERNALERROR> Traceback (most recent call last):
> INTERNALERROR>   File "C:\Python27\lib\site-packages\_pytest\main.py", line 98, in wrap_session
> INTERNALERROR>     session.exitstatus = doit(config, session) or 0
> INTERNALERROR>   File "C:\Python27\lib\site-packages\_pytest\main.py", line 133, in _main
> INTERNALERROR>     config.hook.pytest_runtestloop(session=session)
> INTERNALERROR>   File "C:\Python27\lib\site-packages\_pytest\vendored_packages\pluggy.py", line 745, in __call__
> INTERNALERROR>     return self._hookexec(self, self._nonwrappers + self._wrappers, kwargs)
> INTERNALERROR>   File "C:\Python27\lib\site-packages\_pytest\vendored_packages\pluggy.py", line 339, in _hookexec
> INTERNALERROR>     return self._inner_hookexec(hook, methods, kwargs)
> INTERNALERROR>   File "C:\Python27\lib\site-packages\_pytest\vendored_packages\pluggy.py", line 334, in <lambda>
> INTERNALERROR>     _MultiCall(methods, kwargs, hook.spec_opts).execute()
> INTERNALERROR>   File "C:\Python27\lib\site-packages\_pytest\vendored_packages\pluggy.py", line 614, in execute
> INTERNALERROR>     res = hook_impl.function(*args)
> INTERNALERROR>   File "C:\Python27\lib\site-packages\_pytest\main.py", line 154, in pytest_runtestloop
> INTERNALERROR>     item.config.hook.pytest_runtest_protocol(item=item, nextitem=nextitem)
> INTERNALERROR>   File "C:\Python27\lib\site-packages\_pytest\vendored_packages\pluggy.py", line 745, in __call__
> INTERNALERROR>     return self._hookexec(self, self._nonwrappers + self._wrappers, kwargs)
> INTERNALERROR>   File "C:\Python27\lib\site-packages\_pytest\vendored_packages\pluggy.py", line 339, in _hookexec
> INTERNALERROR>     return self._inner_hookexec(hook, methods, kwargs)
> INTERNALERROR>   File "C:\Python27\lib\site-packages\_pytest\vendored_packages\pluggy.py", line 334, in <lambda>
> INTERNALERROR>     _MultiCall(methods, kwargs, hook.spec_opts).execute()
> INTERNALERROR>   File "C:\Python27\lib\site-packages\_pytest\vendored_packages\pluggy.py", line 613, in execute
> INTERNALERROR>     return _wrapped_call(hook_impl.function(*args), self.execute)
> INTERNALERROR>   File "C:\Python27\lib\site-packages\_pytest\vendored_packages\pluggy.py", line 254, in _wrapped_call
> INTERNALERROR>     return call_outcome.get_result()
> INTERNALERROR>   File "C:\Python27\lib\site-packages\_pytest\vendored_packages\pluggy.py", line 280, in get_result
> INTERNALERROR>     _reraise(*ex)  # noqa
> INTERNALERROR>   File "C:\Python27\lib\site-packages\_pytest\vendored_packages\pluggy.py", line 265, in __init__
> INTERNALERROR>     self.result = func()
> INTERNALERROR>   File "C:\Python27\lib\site-packages\_pytest\vendored_packages\pluggy.py", line 613, in execute
> INTERNALERROR>     return _wrapped_call(hook_impl.function(*args), self.execute)
> INTERNALERROR>   File "C:\Python27\lib\site-packages\_pytest\vendored_packages\pluggy.py", line 254, in _wrapped_call
> INTERNALERROR>     return call_outcome.get_result()
> INTERNALERROR>   File "C:\Python27\lib\site-packages\_pytest\vendored_packages\pluggy.py", line 280, in get_result
> INTERNALERROR>     _reraise(*ex)  # noqa
> INTERNALERROR>   File "C:\Python27\lib\site-packages\_pytest\vendored_packages\pluggy.py", line 265, in __init__
> INTERNALERROR>     self.result = func()
> INTERNALERROR>   File "C:\Python27\lib\site-packages\_pytest\vendored_packages\pluggy.py", line 614, in execute
> INTERNALERROR>     res = hook_impl.function(*args)
> INTERNALERROR>   File "C:\Users\User\env_venv\lib\site-packages\pytest_rerunfailures.py", line 82, in pytest_runtest_protocol
> INTERNALERROR>     item.ihook.pytest_runtest_logreport(report=report)
> INTERNALERROR>   File "C:\Python27\lib\site-packages\_pytest\vendored_packages\pluggy.py", line 745, in __call__
> INTERNALERROR>     return self._hookexec(self, self._nonwrappers + self._wrappers, kwargs)
> INTERNALERROR>   File "C:\Python27\lib\site-packages\_pytest\vendored_packages\pluggy.py", line 339, in _hookexec
> INTERNALERROR>     return self._inner_hookexec(hook, methods, kwargs)
> INTERNALERROR>   File "C:\Python27\lib\site-packages\_pytest\vendored_packages\pluggy.py", line 334, in <lambda>
> INTERNALERROR>     _MultiCall(methods, kwargs, hook.spec_opts).execute()
> INTERNALERROR>   File "C:\Python27\lib\site-packages\_pytest\vendored_packages\pluggy.py", line 614, in execute
> INTERNALERROR>     res = hook_impl.function(*args)
> INTERNALERROR>   File "C:\Users\User\env_venv\lib\site-packages\pytest_html\plugin.py", line 472, in pytest_runtest_logreport
> INTERNALERROR>     self.append_failed(report)
> INTERNALERROR>   File "C:\Users\User\env_venv\lib\site-packages\pytest_html\plugin.py", line 284, in append_failed
> INTERNALERROR>     self._appendrow('Failed', report)
> INTERNALERROR>   File "C:\Users\User\env_venv\lib\site-packages\pytest_html\plugin.py", line 256, in _appendrow
> INTERNALERROR>     result = self.TestResult(outcome, report, self.logfile, self.config)
> INTERNALERROR>   File "C:\Users\User\env_venv\lib\site-packages\pytest_html\plugin.py", line 112, in __init__
> INTERNALERROR>     self.append_extra_html(extra, extra_index, test_index)
> INTERNALERROR>   File "C:\Users\User\env_venv\lib\site-packages\pytest_html\plugin.py", line 211, in append_extra_html
> INTERNALERROR>     extra.get('extension'))
> INTERNALERROR>   File "C:\Users\User\env_venv\lib\site-packages\pytest_html\plugin.py", line 156, in create_asset
> INTERNALERROR>     f.write(content)
> INTERNALERROR>   File "C:\Users\User\env_venv\lib\codecs.py", line 706, in write
> INTERNALERROR>     return self.writer.write(data)
> INTERNALERROR>   File "C:\Users\User\env_venv\lib\codecs.py", line 369, in write
> INTERNALERROR>     data, consumed = self.encode(object, self.errors)
> INTERNALERROR> UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 52714: ordinal not in range(128)

I suggest this fix. Please review it.