### PR TITLE
Fix render metadata list value

### DIFF
--- a/pytest_html/plugin.py
+++ b/pytest_html/plugin.py
@@ -441,7 +441,7 @@ class HTMLReport(object):
             if isinstance(value, basestring) and value.startswith('http'):
                 value = html.a(value, href=value, target='_blank')
             elif isinstance(value, (list, tuple, set)):
-                value = ', '.join(value)
+                value = ', '.join((str(i) for i in value))
             rows.append(html.tr(html.td(key), html.td(value)))
 
         environment.append(html.table(rows, id='environment'))

--- a/pytest_html/plugin.py
+++ b/pytest_html/plugin.py
@@ -14,6 +14,7 @@ import time
 import bisect
 import hashlib
 import warnings
+import collections
 
 try:
     from ansi2html import Ansi2HTMLConverter, style
@@ -440,8 +441,8 @@ class HTMLReport(object):
             value = metadata[key]
             if isinstance(value, basestring) and value.startswith('http'):
                 value = html.a(value, href=value, target='_blank')
-            elif type(value) is list:
-                value = ', '.join(list)
+            elif isinstance(value, (list, tuple, set)):
+                value = ', '.join(value)
             rows.append(html.tr(html.td(key), html.td(value)))
 
         environment.append(html.table(rows, id='environment'))

--- a/pytest_html/plugin.py
+++ b/pytest_html/plugin.py
@@ -440,6 +440,8 @@ class HTMLReport(object):
             value = metadata[key]
             if isinstance(value, basestring) and value.startswith('http'):
                 value = html.a(value, href=value, target='_blank')
+            elif type(value) is list:
+                value = ', '.join(list)
             rows.append(html.tr(html.td(key), html.td(value)))
 
         environment.append(html.table(rows, id='environment'))

--- a/pytest_html/plugin.py
+++ b/pytest_html/plugin.py
@@ -14,7 +14,6 @@ import time
 import bisect
 import hashlib
 import warnings
-import collections
 
 try:
     from ansi2html import Ansi2HTMLConverter, style

--- a/testing/test_pytest_html.py
+++ b/testing/test_pytest_html.py
@@ -493,7 +493,9 @@ class TestHTML:
     def test_environment_list_value(self, testdir):
         content = tuple(str(random.random()) for i in range(10))
         expected_content = ', '.join(content)
-        expected_html_re = '<td>content</td>\n\s+<td>{}</td>'.format(expected_content)
+        expected_html_re = '<td>content</td>\n\s+<td>{}</td>'.format(
+            expected_content
+        )
         testdir.makeconftest("""
             def pytest_configure(config):
                 for i in range(2):

--- a/testing/test_pytest_html.py
+++ b/testing/test_pytest_html.py
@@ -492,7 +492,8 @@ class TestHTML:
 
     def test_environment_list_value(self, testdir):
         content = tuple(str(random.random()) for i in range(10))
-        expected_content = ', '.join(content)
+        content += tuple(random.random() for i in range(10))
+        expected_content = ', '.join((str(i) for i in content))
         expected_html_re = '<td>content</td>\n\s+<td>{}</td>'.format(
             expected_content
         )

--- a/testing/test_pytest_html.py
+++ b/testing/test_pytest_html.py
@@ -489,6 +489,22 @@ class TestHTML:
         assert result.ret
         assert 'Environment' in html
         assert len(re.findall(content, html)) == 1
+    
+    def test_environment_list_value(self, testdir):
+        content = tuple(str(random.random()) for i in range(10))
+        expected_content = ', '.join(content)
+        expected_html_re='<td>content</td>\n\s+<td>{}</td>'.format(expected_content)
+        testdir.makeconftest("""
+            def pytest_configure(config):
+                for i in range(2):
+                    config._metadata['content'] = {0}
+        """.format(content))
+        testdir.makepyfile('def test_pass(): pass')
+        result, html = run(testdir)
+        assert result.ret == 0
+        assert 'Environment' in html
+        assert len(re.findall(expected_html_re, html)) == 1
+
 
     @pytest.mark.xfail(
         sys.version_info < (3, 2) and

--- a/testing/test_pytest_html.py
+++ b/testing/test_pytest_html.py
@@ -489,11 +489,11 @@ class TestHTML:
         assert result.ret
         assert 'Environment' in html
         assert len(re.findall(content, html)) == 1
-    
+
     def test_environment_list_value(self, testdir):
         content = tuple(str(random.random()) for i in range(10))
         expected_content = ', '.join(content)
-        expected_html_re='<td>content</td>\n\s+<td>{}</td>'.format(expected_content)
+        expected_html_re = '<td>content</td>\n\s+<td>{}</td>'.format(expected_content)
         testdir.makeconftest("""
             def pytest_configure(config):
                 for i in range(2):
@@ -504,7 +504,6 @@ class TestHTML:
         assert result.ret == 0
         assert 'Environment' in html
         assert len(re.findall(expected_html_re, html)) == 1
-
 
     @pytest.mark.xfail(
         sys.version_info < (3, 2) and


### PR DESCRIPTION
I wanted to show a lists of file names in the metadata view but they were concatenated together in one long string. I think it would be more useful if list like types are rendered as strings with comma seperators.