### PR TITLE
adds hook to edit metadata before writing to Environment section

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -85,6 +85,17 @@ via the :code:`pytest_configure` hook:
   def pytest_configure(config):
       config._metadata['foo'] = 'bar'
 
+You can make changes to the metadata before it's written to the *Environment* section via the :code:`pytest_html_environment_section_metadata` hook. The following example :code:`conftest.py` removes metadata entries of which the key contains "password":
+
+.. code-block:: python
+
+  @pytest.mark.optionalhook
+  def pytest_html_environment_section_metadata(metadata):
+    for key in [k for k in metadata.keys() if metadata[k]]:
+        if "password" in key.lower():
+        del metadata[key]
+
+
 Extra content
 ~~~~~~~~~~~~~
 

--- a/pytest_html/hooks.py
+++ b/pytest_html/hooks.py
@@ -3,6 +3,10 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
+def pytest_html_environment_section_metadata(metadata):
+    """ Called after collecting metadata for Environment section. """
+
+
 def pytest_html_results_table_header(cells):
     """ Called after building results table header. """
 

--- a/pytest_html/plugin.py
+++ b/pytest_html/plugin.py
@@ -440,6 +440,8 @@ class HTMLReport(object):
             return []
 
         metadata = config._metadata
+        config.hook.pytest_html_environment_section_metadata(metadata=metadata)
+
         environment = [html.h2('Environment')]
         rows = []
 


### PR DESCRIPTION
Running tests on our CI environment creates a lot of metadata and thus a huge Environment table in the report. So I'd like to be able to filter which metadata ends up in the Environment table, so I added a hook to edit the metadata before it's processed by the plugin.

This is my first PR to an open source repo. If I'm not submitting this the proper way, please let me know and I'll fix it. Thanks!