### PR TITLE
adds filename of report as title to html body

### DIFF
--- a/pytest_html/plugin.py
+++ b/pytest_html/plugin.py
@@ -414,6 +414,7 @@ class HTMLReport(object):
 
         body = html.body(
             html.script(raw(main_js)),
+            html.h1(os.path.basename(session.config.option.htmlpath)),
             html.p('Report generated on {0} at {1} by'.format(
                 generated.strftime('%d-%b-%Y'),
                 generated.strftime('%H:%M:%S')),

--- a/pytest_html/resources/style.css
+++ b/pytest_html/resources/style.css
@@ -4,6 +4,12 @@ body {
 	min-width: 1200px;
 	color: #999;
 }
+
+h1 {
+	font-size: 24px;
+	color: black;
+}
+
 h2 {
 	font-size: 16px;
 	color: black;

--- a/testing/test_pytest_html.py
+++ b/testing/test_pytest_html.py
@@ -181,6 +181,16 @@ class TestHTML:
         assert result.ret == 0
         assert_results(html)
 
+    @pytest.mark.parametrize('path', ['', 'directory'])
+    def test_report_title(self, testdir, path):
+        testdir.makepyfile('def test_pass(): pass')
+        report_name = 'report.html'
+        path = os.path.join(path, report_name)
+        result, html = run(testdir, path)
+        assert result.ret == 0
+        report_title = "<h1>{0}</h1>".format(report_name)
+        assert report_title in html
+
     def test_resources_inline_css(self, testdir):
         testdir.makepyfile('def test_pass(): pass')
         result, html = run(testdir, 'report.html', '--self-contained-html')


### PR DESCRIPTION
We have a CI dashboard with links to the reports generated for different tests. I'd like to see the filename of the report as title in the body, so it's clear which test results I'm looking at.

Note: I made the assumption that `os.path.basename` will work across platforms.