### PR TITLE
Add option to split report

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -240,6 +240,45 @@ additional HTML and log output with a notice that the log is empty:
           del data[:]
           data.append(html.div('No log output captured.', class_='empty log'))
 
+Grouping test results
+~~~~~~~~~~~~~~~~~~~~~
+
+By default, the generated report will be a flat array containing the results of all the defined
+tests. It is possible to group these results by defining some keys. It also allows defining a group
+hierarchy of undefined depth.
+
+Group keys are defined in the :code:`pytest_runtest_makereport` hook. The following example defines
+2 keys `key1` and `key2` whose value will be the `argx` and `argy` values passed to the test.
+
+.. code-block:: python
+
+  import pytest
+  @pytest.mark.hookwrapper
+  def pytest_runtest_makereport(item, call):
+      outcome = yield
+      report = outcome.get_result()
+      report.key1 = item.funcargs["argx"]
+      report.key2 = item.funcargs["argy"]
+
+Then to generate a grouped report, you can use the `--group-by` option:
+
+.. code-block:: bash
+
+  $ pytest --html=report.html --group-by key1 --group-by key2
+
+Keys will be considered in the order the are given on the command line. The previous example will
+generate the following hierarchy:
+
+.. code-block::
+
+   key1 = "Value 1"
+   |-- key2 = "Value 1.1"
+   |-- key2 = "Value 1.2"
+   key1 = "Value 2"
+   |-- key2 = "Value 2.1"
+   |-- key2 = "Value 2.2"
+
+
 Display options
 ---------------
 

--- a/pytest_html/plugin.py
+++ b/pytest_html/plugin.py
@@ -440,7 +440,10 @@ class HTMLReport(object):
 
         body.extend(self._generate_environment(session.config))
 
-        body.extend(self._generate_summary(session, ['_default']))
+        include_outcome = not self.group_report_keys
+        body.extend(self._generate_summary(session,
+                                           ['_default'],
+                                           include_outcome=include_outcome))
 
         if not self.group_report_keys:
             results = self._generate_results(session, ['_default'])
@@ -501,7 +504,8 @@ class HTMLReport(object):
 
         return links_summary, results
 
-    def _generate_summary(self, session, key, prefix_id='', h_summary=html.h2):
+    def _generate_summary(self, session, key,
+                          prefix_id='', h_summary=html.h2, include_outcome=True):
         class Outcome:
 
             def __init__(self, outcome, total=0, label=None,
@@ -579,16 +583,17 @@ class HTMLReport(object):
         if key == ['_default']:
             summary_text += ' in {:.2f} seconds.'.format(self.suite_time_delta)
 
-        summary = [html.p(summary_text),
-                   html.p('(Un)check the boxes to filter the results.',
-                          class_='filter',
-                          hidden='true')]
+        summary = [html.p(summary_text)]
 
-        for i, outcome in enumerate(outcomes, start=1):
-            summary.append(outcome.checkbox)
-            summary.append(outcome.summary_item)
-            if i < len(outcomes):
-                summary.append(', ')
+        if include_outcome:
+            summary.append(html.p('(Un)check the boxes to filter the results.',
+                                  class_='filter',
+                                  hidden='true'))
+            for i, outcome in enumerate(outcomes, start=1):
+                summary.append(outcome.checkbox)
+                summary.append(outcome.summary_item)
+                if i < len(outcomes):
+                    summary.append(', ')
 
         summary_prefix, summary_postfix = [], []
         session.config.hook.pytest_html_results_summary(

--- a/pytest_html/plugin.py
+++ b/pytest_html/plugin.py
@@ -423,7 +423,6 @@ class HTMLReport(object):
             html.title('Test Report'),
             html_css)
 
-
         main_js = pkg_resources.resource_string(
             __name__, os.path.join('resources', 'main.js'))
         if PY3:
@@ -493,7 +492,10 @@ class HTMLReport(object):
                 li.append(html.ul(sublinks))
             else:
                 subres = self._generate_summary(session, key, prefix_id)
-                subres.extend(self._generate_results(session, key, prefix_id, h_result))
+                subres.extend(self._generate_results(session,
+                                                     key,
+                                                     prefix_id,
+                                                     h_result))
             links_summary.append(li)
             results.extend(subres)
 
@@ -516,9 +518,10 @@ class HTMLReport(object):
                 self.generate_summary_item()
 
             def generate_checkbox(self):
+                data_pref = convert_key_to_id(self.prefix_id)
                 checkbox_kwargs = {'data-test-result':
                                    self.test_result.lower(),
-                                   'data-prefix-id': convert_key_to_id(self.prefix_id)}
+                                   'data-prefix-id': data_pref}
                 if self.total == 0:
                     checkbox_kwargs['disabled'] = 'true'
 
@@ -574,7 +577,7 @@ class HTMLReport(object):
 
         summary_text = '{} tests ran'.format(numtests)
         if key == ['_default']:
-            summary_text += ' in {:.2f} seconds. '.format(self.suite_time_delta)
+            summary_text += ' in {:.2f} seconds.'.format(self.suite_time_delta)
 
         summary = [html.p(summary_text),
                    html.p('(Un)check the boxes to filter the results.',
@@ -591,9 +594,10 @@ class HTMLReport(object):
         session.config.hook.pytest_html_results_summary(
             prefix=summary_prefix, summary=summary, postfix=summary_postfix)
 
-        summary = [h_summary('Summary')] + summary_prefix + summary + summary_postfix
-
-        return summary
+        return ([h_summary('Summary')] +
+                summary_prefix +
+                summary +
+                summary_postfix)
 
     def _generate_results(self, session, key, prefix_id='', h_result=html.h2):
         cells = [

--- a/pytest_html/resources/main.js
+++ b/pytest_html/resources/main.js
@@ -38,12 +38,12 @@ function sort_column(elem) {
     sort_table(elem, key(colIndex));
 }
 
-function show_all_extras() {
-    find_all('.col-result').forEach(show_extras);
+function show_all_extras(table_id) {
+    find_all('.col-result', find('#' + table_id)).forEach(show_extras);
 }
 
-function hide_all_extras() {
-    find_all('.col-result').forEach(hide_extras);
+function hide_all_extras(table_id) {
+    find_all('.col-result', find('#' + table_id)).forEach(hide_extras);
 }
 
 function show_extras(colresult_elem) {
@@ -70,11 +70,12 @@ function show_filters() {
 
 function add_collapse() {
     // Add links for show/hide all
-    var resulttable = find('table#results-table');
-    var showhideall = document.createElement("p");
-    showhideall.innerHTML = '<a href="javascript:show_all_extras()">Show all details</a> / ' +
-                            '<a href="javascript:hide_all_extras()">Hide all details</a>';
-    resulttable.parentElement.insertBefore(showhideall, resulttable);
+    find_all('table.results-table').forEach(function(resulttable) {
+        var showhideall = document.createElement("p");
+        showhideall.innerHTML = '<a href="javascript:show_all_extras(\'' + resulttable.id + '\')">Show all details</a> / ' +
+            '<a href="javascript:hide_all_extras(\'' + resulttable.id + '\')">Hide all details</a>';
+        resulttable.parentElement.insertBefore(showhideall, resulttable);
+    });
 
     // Add show/hide link to each result
     find_all('.col-result').forEach(function(elem) {
@@ -123,21 +124,23 @@ function init () {
 };
 
 function sort_table(clicked, key_func) {
-    var rows = find_all('.results-table-row');
+    var table = clicked.parentNode.parentNode.parentNode;
+    var previous_sibling = table.previousSibling;
+    var rows = find_all('.results-table-row', table);
     var reversed = !clicked.classList.contains('asc');
     var sorted_rows = sort(rows, key_func, reversed);
     /* Whole table is removed here because browsers acts much slower
      * when appending existing elements.
      */
-    var thead = document.getElementById("results-table-head");
-    document.getElementById('results-table').remove();
+    var thead = find('thead', table);
+    table.remove();
     var parent = document.createElement("table");
-    parent.id = "results-table";
+    parent.id = table.id;
     parent.appendChild(thead);
     sorted_rows.forEach(function(elem) {
         parent.appendChild(elem);
     });
-    document.getElementsByTagName("BODY")[0].appendChild(parent);
+    previous_sibling.parentNode.insertBefore(parent, previous_sibling.nextSibling);
 }
 
 function sort(items, key_func, reversed) {
@@ -214,14 +217,15 @@ function is_all_rows_hidden(value) {
 function filter_table(elem) {
     var outcome_att = "data-test-result";
     var outcome = elem.getAttribute(outcome_att);
-    class_outcome = outcome + " results-table-row";
-    var outcome_rows = document.getElementsByClassName(class_outcome);
+    var class_outcome = outcome + " results-table-row";
+    var table = find("#results-table");
+    var outcome_rows = table.getElementsByClassName(class_outcome);
 
     for(var i = 0; i < outcome_rows.length; i++){
         outcome_rows[i].hidden = !elem.checked;
     }
 
-    var rows = find_all('.results-table-row').filter(is_all_rows_hidden);
+    var rows = find_all('.results-table-row', table).filter(is_all_rows_hidden);
     var all_rows_hidden = rows.length == 0 ? true : false;
     var not_found_message = document.getElementById("not-found-message");
     not_found_message.hidden = !all_rows_hidden;

--- a/pytest_html/resources/main.js
+++ b/pytest_html/resources/main.js
@@ -218,7 +218,8 @@ function filter_table(elem) {
     var outcome_att = "data-test-result";
     var outcome = elem.getAttribute(outcome_att);
     var class_outcome = outcome + " results-table-row";
-    var table = find("#results-table");
+    var prefix_id = elem.getAttribute("data-prefix-id");
+    var table = find("#" + prefix_id + "results-table");
     var outcome_rows = table.getElementsByClassName(class_outcome);
 
     for(var i = 0; i < outcome_rows.length; i++){
@@ -227,6 +228,6 @@ function filter_table(elem) {
 
     var rows = find_all('.results-table-row', table).filter(is_all_rows_hidden);
     var all_rows_hidden = rows.length == 0 ? true : false;
-    var not_found_message = document.getElementById("not-found-message");
+    var not_found_message = document.getElementById(prefix_id + "not-found-message");
     not_found_message.hidden = !all_rows_hidden;
 }

--- a/pytest_html/resources/style.css
+++ b/pytest_html/resources/style.css
@@ -67,19 +67,19 @@ span.error, span.failed, span.xpassed, .error .col-result, .failed .col-result, 
  * 1. Table Layout
  *------------------*/
 
-#results-table {
+.results-table {
 	border: 1px solid #e6e6e6;
 	color: #999;
 	font-size: 12px;
 	width: 100%
 }
 
-#results-table th, #results-table td {
+.results-table th, .results-table td {
 	padding: 5px;
 	border: 1px solid #E6E6E6;
 	text-align: left
 }
-#results-table th {
+.results-table th {
 	font-weight: bold
 }
 

--- a/testing/test_pytest_html.py
+++ b/testing/test_pytest_html.py
@@ -37,6 +37,7 @@ def assert_results_by_outcome(html, test_outcome, test_outcome_number,
 
     # Asserts if the generated checkbox of this outcome is correct
     regex_checkbox = ('<input checked="true" class="filter" '
+                      'data-prefix-id="([^"]*)" '
                       'data-test-result="{0}"'.format(test_outcome))
     if test_outcome_number == 0:
         regex_checkbox += ' disabled="true"'


### PR DESCRIPTION
Add a new "--split-by" option that allows to split report per user-specified keys.
This is close to what was described in #33 (I think), but gives the user the flexibility to choose how to split the reports.

To do this, one must call pytest passing along one or more "--split-by" values. These are ordered values that will be used as keys to split and group reports in a hierarchy. These keys **MUST** be present in the report instance. They can be set in eg. the pytest_runtest_makereport hook.

For example, by defining:
```
@pytest.mark.hookwrapper
def pytest_runtest_makereport(item, call):
    outcome = yield
    report = outcome.get_result()
    <...>
    report.language = f'{lang.title()}'
    report.lib = lib
```

then it can be called with ``pytest --split-by language --split-by lib`` and will generate reports grouped by language/lib.

If not option is passed in the ``pytest`` invocation, then the current, unified report is generated.