### PR TITLE
Always define __version__ even if get_distribution() fails

### DIFF
--- a/pytest_html/__init__.py
+++ b/pytest_html/__init__.py
@@ -5,6 +5,6 @@ try:
     __version__ = get_distribution(__name__).version
 except DistributionNotFound:
     # package is not installed
-    pass
+    __version__ = 'unknown'
 
 __pypi_url__ = 'https://pypi.python.org/pypi/pytest-html'


### PR DESCRIPTION
In frozen executables created with tools such as pyinstaller, get_distribution() does not work because it looks for files in the environment which are not packed in the
executable.

This patch makes `__version__` available in those situations, otherwise the
plugin won't work at all because `plugin.py` tries to import `__version__`
from `pytest_html.__init__`.