### PR TITLE
Change assets naming method

### DIFF
--- a/pytest_html/plugin.py
+++ b/pytest_html/plugin.py
@@ -58,8 +58,6 @@ def pytest_addoption(parser):
                     'https://developer.mozilla.org/docs/Web/Security/CSP)')
     group.addoption('--css', action='append', metavar='path', default=[],
                     help='append given css file content to report style file.')
-    group.addoption('--assets_name_hashing', action='store', default=True,
-                    help='when True, assets names are hashed')
 
 
 def pytest_configure(config):
@@ -71,6 +69,7 @@ def pytest_configure(config):
             # prevent opening htmlpath on slave nodes (xdist)
             config._html = HTMLReport(htmlpath, config)
             config.pluginmanager.register(config._html)
+    config.assets_name_hashing = True
 
 
 def pytest_unconfigure(config):
@@ -147,7 +146,7 @@ class HTMLReport(object):
 
         def create_asset(self, content, extra_index,
                          test_index, file_extension, mode='w'):
-            assets_hashing = self.config.getoption('assets_name_hashing')
+            assets_hashing = self.config.assets_name_hashing
             hash_key = ''.join([self.test_id, str(extra_index),
                                 str(test_index)]).encode('utf-8')
             if assets_hashing:

--- a/pytest_html/plugin.py
+++ b/pytest_html/plugin.py
@@ -150,7 +150,9 @@ class HTMLReport(object):
                                 str(test_index)])
             hash_generator = hashlib.md5()
             hash_generator.update(hash_key.encode('utf-8'))
-            asset_file_name = '{0}_{1}.{2}'.format(hash_key, hash_generator.hexdigest(), file_extension)
+            asset_file_name = '{0}_{1}.{2}'.format(hash_key,
+                                                   hash_generator.hexdigest(),
+                                                   file_extension)
             asset_path = os.path.join(os.path.dirname(self.logfile),
                                       'assets', asset_file_name)
             if not os.path.exists(os.path.dirname(asset_path)):

--- a/pytest_html/plugin.py
+++ b/pytest_html/plugin.py
@@ -69,7 +69,6 @@ def pytest_configure(config):
             # prevent opening htmlpath on slave nodes (xdist)
             config._html = HTMLReport(htmlpath, config)
             config.pluginmanager.register(config._html)
-    config.assets_name_hashing = True
 
 
 def pytest_unconfigure(config):
@@ -146,18 +145,12 @@ class HTMLReport(object):
 
         def create_asset(self, content, extra_index,
                          test_index, file_extension, mode='w'):
-            assets_hashing = self.config.assets_name_hashing
-            hash_key = ''.join([self.test_id, str(extra_index),
-                                str(test_index)]).encode('utf-8')
-            if assets_hashing:
-                hash_generator = hashlib.md5()
-                hash_generator.update(hash_key)
-                file_name = hash_generator.hexdigest()
-            else:
-                file_name = hash_key
 
-            asset_file_name = '{0}.{1}'.format(file_name,
-                                               file_extension)
+            hash_key = ''.join([self.test_id, str(extra_index),
+                                str(test_index)])
+            hash_generator = hashlib.md5()
+            hash_generator.update(hash_key.encode('utf-8'))
+            asset_file_name = '{0}_{1}.{2}'.format(hash_key, hash_generator.hexdigest(), file_extension)
             asset_path = os.path.join(os.path.dirname(self.logfile),
                                       'assets', asset_file_name)
             if not os.path.exists(os.path.dirname(asset_path)):

--- a/pytest_html/plugin.py
+++ b/pytest_html/plugin.py
@@ -58,6 +58,8 @@ def pytest_addoption(parser):
                     'https://developer.mozilla.org/docs/Web/Security/CSP)')
     group.addoption('--css', action='append', metavar='path', default=[],
                     help='append given css file content to report style file.')
+    group.addoption('--assets_name_hashing', action='store', default=True,
+                    help='when True, assets names are hashed')
 
 
 def pytest_configure(config):
@@ -145,11 +147,17 @@ class HTMLReport(object):
 
         def create_asset(self, content, extra_index,
                          test_index, file_extension, mode='w'):
+            assets_hashing = self.config.getoption('assets_name_hashing')
             hash_key = ''.join([self.test_id, str(extra_index),
                                 str(test_index)]).encode('utf-8')
-            hash_generator = hashlib.md5()
-            hash_generator.update(hash_key)
-            asset_file_name = '{0}.{1}'.format(hash_generator.hexdigest(),
+            if assets_hashing:
+                hash_generator = hashlib.md5()
+                hash_generator.update(hash_key)
+                file_name = hash_generator.hexdigest()
+            else:
+                file_name = hash_key
+
+            asset_file_name = '{0}.{1}'.format(file_name,
                                                file_extension)
             asset_path = os.path.join(os.path.dirname(self.logfile),
                                       'assets', asset_file_name)

--- a/testing/test_pytest_html.py
+++ b/testing/test_pytest_html.py
@@ -383,12 +383,12 @@ class TestHTML:
         testdir.makepyfile('def test_pass(): pass')
         result, html = run(testdir)
         hash_key = ('test_extra_text_separated.py::'
-                    'test_pass00').encode('utf-8')
+                    'test_pass00')
         hash_generator = hashlib.md5()
-        hash_generator.update(hash_key)
+        hash_generator.update(hash_key.encode('utf-8'))
         assert result.ret == 0
-        src = '{0}/{1}'.format('assets', '{0}.txt'.
-                               format(hash_generator.hexdigest()))
+        src = '{0}/{1}'.format('assets', '{0}_{1}.txt'.
+                               format(hash_key, hash_generator.hexdigest()))
         link = ('<a class="text" href="{0}" target="_blank">'.format(src))
         assert link in html
         assert os.path.exists(src)
@@ -412,14 +412,12 @@ class TestHTML:
         """.format(extra_type, content))
         testdir.makepyfile('def test_pass(): pass')
         result, html = run(testdir)
-        hash_key = ('test_extra_image_separated.py::'
-                    'test_pass00').encode('utf-8')
+        hash_key = 'test_extra_image_separated.py::test_pass00'
         hash_generator = hashlib.md5()
-        hash_generator.update(hash_key)
+        hash_generator.update(hash_key.encode('utf-8'))
         assert result.ret == 0
-        src = '{0}/{1}'.format('assets', '{0}.{1}'.
-                               format(hash_generator.hexdigest(),
-                                      file_extension))
+        src = '{0}/{1}'.format('assets', '{0}_{1}.{2}'.
+                               format(hash_key, hash_generator.hexdigest(), file_extension))
         link = ('<a class="image" href="{0}" target="_blank">'.format(src))
         assert link in html
         assert os.path.exists(src)
@@ -454,7 +452,7 @@ class TestHTML:
                         'test_fail0{0}'.format(i)).encode('utf-8')
             hash_generator = hashlib.md5()
             hash_generator.update(hash_key)
-            src = 'assets/{0}.{1}'.format(hash_generator.hexdigest(),
+            src = 'assets/{0}_{1}.{2}'.format(hash_key, hash_generator.hexdigest(),
                                           file_extension)
             link = ('<a class="image" href="{0}" target="_blank">'.format(src))
             assert result.ret

--- a/testing/test_pytest_html.py
+++ b/testing/test_pytest_html.py
@@ -449,9 +449,9 @@ class TestHTML:
 
         for i in range(1, 4):
             hash_key = ('test_extra_image_separated_rerun.py::'
-                        'test_fail0{0}'.format(i)).encode('utf-8')
+                        'test_fail0{0}'.format(i))
             hash_generator = hashlib.md5()
-            hash_generator.update(hash_key)
+            hash_generator.update(hash_key.encode('utf-8'))
             src = 'assets/{0}_{1}.{2}'.format(hash_key, hash_generator.hexdigest(),
                                           file_extension)
             link = ('<a class="image" href="{0}" target="_blank">'.format(src))

--- a/testing/test_pytest_html.py
+++ b/testing/test_pytest_html.py
@@ -416,8 +416,9 @@ class TestHTML:
         hash_generator = hashlib.md5()
         hash_generator.update(hash_key.encode('utf-8'))
         assert result.ret == 0
-        src = '{0}/{1}'.format('assets', '{0}_{1}.{2}'.
-                               format(hash_key, hash_generator.hexdigest(), file_extension))
+        src = '{0}/{1}'.format('assets', '{0}_{1}.{2}'.format(hash_key,
+                                                              hash_generator.hexdigest(),
+                                                              file_extension))
         link = ('<a class="image" href="{0}" target="_blank">'.format(src))
         assert link in html
         assert os.path.exists(src)
@@ -452,8 +453,9 @@ class TestHTML:
                         'test_fail0{0}'.format(i))
             hash_generator = hashlib.md5()
             hash_generator.update(hash_key.encode('utf-8'))
-            src = 'assets/{0}_{1}.{2}'.format(hash_key, hash_generator.hexdigest(),
-                                          file_extension)
+            src = 'assets/{0}_{1}.{2}'.format(hash_key,
+                                              hash_generator.hexdigest(),
+                                              file_extension)
             link = ('<a class="image" href="{0}" target="_blank">'.format(src))
             assert result.ret
             assert link in html

--- a/testing/test_pytest_html.py
+++ b/testing/test_pytest_html.py
@@ -416,9 +416,9 @@ class TestHTML:
         hash_generator = hashlib.md5()
         hash_generator.update(hash_key.encode('utf-8'))
         assert result.ret == 0
-        src = '{0}/{1}'.format('assets', '{0}_{1}.{2}'.format(hash_key,
-                                                              hash_generator.hexdigest(),
-                                                              file_extension))
+        src = '{0}/{1}'.format('assets', '{0}_{1}.{2}'.
+                               format(hash_key, hash_generator.hexdigest(),
+                                      file_extension))
         link = ('<a class="image" href="{0}" target="_blank">'.format(src))
         assert link in html
         assert os.path.exists(src)


### PR DESCRIPTION
A little context:
I've been using pytest_html for layouts testing, sometimes reports contains about 100 mb of images, which is hard to navigate in browser. It would be nice if I could just scroll throw my assets and watch which test-case was failed in my file manager. 
I found out that assets naming contains exact info I need, but in some reason it hashed. 
So I added an option assets_name_hashing. When it's set False, assets names are not hashed and can be sorted nicely in folder. 

What do you think? 

Update: 
now all assets named like "test_name_[hash].jpg"