### PR TITLE
Handle when report title is stored as an environment variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ local.properties
 
 ##Tests JS
 node_modules/
+
+Pipfile

--- a/pytest_html/plugin.py
+++ b/pytest_html/plugin.py
@@ -432,7 +432,7 @@ class HTMLReport(object):
 
         body = html.body(
             html.script(raw(main_js)),
-            html.h1(os.path.basename(session.config.option.htmlpath)),
+            html.h1(os.path.basename(self.logfile)),
             html.p('Report generated on {0} at {1} by '.format(
                 generated.strftime('%d-%b-%Y'),
                 generated.strftime('%H:%M:%S')),


### PR DESCRIPTION
When the --html flag is used in pytest.ini with "addopts" and the
report title is stored in an environment variable, the name of the
environment variable was used as the report title.

In other words, the environment variable was never expanded.

Fixes: #201