### PR TITLE
Allow opening generated html report in browser

### DIFF
--- a/pytest_html/plugin.py
+++ b/pytest_html/plugin.py
@@ -521,5 +521,6 @@ class HTMLReport(object):
         self._save_report(report_content)
 
     def pytest_terminal_summary(self, terminalreporter):
-        terminalreporter.write_sep('-', 'generated html file: {0}'.format(
-            self.logfile))
+        terminalreporter.write_sep(
+            '-',
+            'generated html file: file://{0}'.format(self.logfile))


### PR DESCRIPTION
By default terminals would open files in editors and URLs in browsers.

By printing the generated html report using an URL (file://) we enable
users to click the terminal to open it. Previously this opened the file
in the text editor which is very unlikely to be what user would want.