### PR TITLE
Append a line break after captured log sections

### DIFF
--- a/pytest_html/plugin.py
+++ b/pytest_html/plugin.py
@@ -263,6 +263,7 @@ class HTMLReport(object):
                     converter = Ansi2HTMLConverter(inline=False, escaped=False)
                     content = converter.convert(content, full=False)
                 log.append(raw(content))
+                log.append(html.br())
 
             if len(log) == 0:
                 log = html.div(class_='empty log')


### PR DESCRIPTION
The content in log sections doesn't always include a trailing newline, so this includes one afterwards ensuring that the next section header is placed on a new line.

This is only really useful if there are multiple log sections, like in the example below. If there's already a trailing newline, this has no effect as it adds a `<br>` tag which doesn't change the spacing at the end of the content.


<details>
<summary>Example</summary>

```python
import pytest


@pytest.fixture()
def logger():
    import logging

    log = logging.getLogger(__name__)
    log.info("before the test")
    return log


def test_log(logger):
    logger.info("during the test")
    raise Exception
```

</details>

<details>
<summary>Before</summary>
<img src="https://user-images.githubusercontent.com/249351/60891393-25b43e00-a255-11e9-8cc5-16f421cefc6b.png">
</details>

<details>
<summary>After</summary>
<img src="https://user-images.githubusercontent.com/249351/60891403-2b118880-a255-11e9-8e3a-64c45216f52b.png">
</details>
