### PR TITLE
Remove unused and undocumented markers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -112,7 +112,6 @@ You can edit the *Summary* section by using the :code:`pytest_html_results_summa
    import pytest
    from py.xml import html
 
-   @pytest.mark.optionalhook
    def pytest_html_results_summary(prefix, summary, postfix):
        prefix.extend([html.p("foo: bar")])
 
@@ -158,7 +157,7 @@ conftest.py file:
 .. code-block:: python
 
   import pytest
-  @pytest.mark.hookwrapper
+  @pytest.hookimpl(hookwrapper=True)
   def pytest_runtest_makereport(item, call):
       pytest_html = item.config.pluginmanager.getplugin('html')
       outcome = yield
@@ -195,19 +194,17 @@ column:
   from py.xml import html
   import pytest
 
-  @pytest.mark.optionalhook
   def pytest_html_results_table_header(cells):
       cells.insert(2, html.th('Description'))
       cells.insert(1, html.th('Time', class_='sortable time', col='time'))
       cells.pop()
 
-  @pytest.mark.optionalhook
   def pytest_html_results_table_row(report, cells):
       cells.insert(2, html.td(report.description))
       cells.insert(1, html.td(datetime.utcnow(), class_='col-time'))
       cells.pop()
 
-  @pytest.mark.hookwrapper
+  @pytest.hookimpl(hookwrapper=True)
   def pytest_runtest_makereport(item, call):
       outcome = yield
       report = outcome.get_result()
@@ -221,7 +218,6 @@ following example removes all passed results from the report:
 
   import pytest
 
-  @pytest.mark.optionalhook
   def pytest_html_results_table_row(report, cells):
       if report.passed:
         del cells[:]
@@ -234,7 +230,6 @@ additional HTML and log output with a notice that the log is empty:
 
   import pytest
 
-  @pytest.mark.optionalhook
   def pytest_html_results_table_html(report, data):
       if report.passed:
           del data[:]

--- a/testing/test_pytest_html.py
+++ b/testing/test_pytest_html.py
@@ -299,7 +299,6 @@ class TestHTML:
             import pytest
             from py.xml import html
 
-            @pytest.mark.optionalhook
             def pytest_html_results_summary(prefix, summary, postfix):
                 prefix.append(html.p("prefix is {0}"))
                 summary.extend([html.p("extra summary is {1}")])
@@ -320,7 +319,7 @@ class TestHTML:
         testdir.makeconftest(
             """
             import pytest
-            @pytest.mark.hookwrapper
+            @pytest.hookimpl(hookwrapper=True)
             def pytest_runtest_makereport(item, call):
                 outcome = yield
                 report = outcome.get_result()
@@ -344,7 +343,7 @@ class TestHTML:
         testdir.makeconftest(
             """
             import pytest
-            @pytest.mark.hookwrapper
+            @pytest.hookimpl(hookwrapper=True)
             def pytest_runtest_makereport(item, call):
                 outcome = yield
                 report = outcome.get_result()
@@ -367,7 +366,7 @@ class TestHTML:
         testdir.makeconftest(
             """
             import pytest
-            @pytest.mark.hookwrapper
+            @pytest.hookimpl(hookwrapper=True)
             def pytest_runtest_makereport(item, call):
                 outcome = yield
                 report = outcome.get_result()
@@ -395,7 +394,7 @@ class TestHTML:
         testdir.makeconftest(
             """
             import pytest
-            @pytest.mark.hookwrapper
+            @pytest.hookimpl(hookwrapper=True)
             def pytest_runtest_makereport(item, call):
                 outcome = yield
                 report = outcome.get_result()
@@ -426,7 +425,7 @@ class TestHTML:
         testdir.makeconftest(
             """
             import pytest
-            @pytest.mark.hookwrapper
+            @pytest.hookimpl(hookwrapper=True)
             def pytest_runtest_makereport(item, call):
                 outcome = yield
                 report = outcome.get_result()
@@ -456,7 +455,7 @@ class TestHTML:
         testdir.makeconftest(
             """
             import pytest
-            @pytest.mark.hookwrapper
+            @pytest.hookimpl(hookwrapper=True)
             def pytest_runtest_makereport(item, call):
                 outcome = yield
                 report = outcome.get_result()
@@ -489,7 +488,7 @@ class TestHTML:
         testdir.makeconftest(
             """
             import pytest
-            @pytest.mark.hookwrapper
+            @pytest.hookimpl(hookwrapper=True)
             def pytest_runtest_makereport(item, call):
                 outcome = yield
                 report = outcome.get_result()
@@ -523,7 +522,7 @@ class TestHTML:
         testdir.makeconftest(
             """
             import pytest
-            @pytest.mark.hookwrapper
+            @pytest.hookimpl(hookwrapper=True)
             def pytest_runtest_makereport(item, call):
                 outcome = yield
                 report = outcome.get_result()
@@ -561,7 +560,7 @@ class TestHTML:
         testdir.makeconftest(
             """
             import pytest
-            @pytest.mark.hookwrapper
+            @pytest.hookimpl(hookwrapper=True)
             def pytest_runtest_makereport(item, call):
                 outcome = yield
                 report = outcome.get_result()
@@ -583,7 +582,7 @@ class TestHTML:
         testdir.makeconftest(
             """
             import pytest
-            @pytest.mark.hookwrapper
+            @pytest.hookimpl(hookwrapper=True)
             def pytest_runtest_makereport(item, call):
                 outcome = yield
                 report = outcome.get_result()
@@ -776,7 +775,7 @@ class TestHTML:
         testdir.makeconftest(
             """
             import pytest
-            @pytest.mark.hookwrapper
+            @pytest.hookimpl(hookwrapper=True)
             def pytest_runtest_makereport(item, call):
                 outcome = yield
                 report = outcome.get_result()


### PR DESCRIPTION
Seems like ´optionalhook´ was never used.

´hookwrapper´ generated `PytestUnknownMarkWarning`

and I couldn't find anything regarding it explicitly in the changelog of `pytest`.

Replaced it with `@pytest.hookimpl(hookwrapper=True)` which did not generate any warnings.

Care to shed some light on the above @nicoddemus @RonnyPfannschmidt ?