### PR TITLE
Close opened resource.

### DIFF
--- a/pytest_html/plugin.py
+++ b/pytest_html/plugin.py
@@ -69,7 +69,7 @@ def pytest_configure(config):
     if htmlpath:
         for csspath in config.getoption("css"):
             if not os.path.exists(csspath):
-                raise IOError("No such file or directory: '{}'".format(csspath))
+                raise IOError(f"No such file or directory: '{csspath}'")
         if not hasattr(config, "slaveinput"):
             # prevent opening htmlpath on slave nodes (xdist)
             config._html = HTMLReport(htmlpath, config)

--- a/pytest_html/plugin.py
+++ b/pytest_html/plugin.py
@@ -68,7 +68,8 @@ def pytest_configure(config):
     htmlpath = config.getoption("htmlpath")
     if htmlpath:
         for csspath in config.getoption("css"):
-            open(csspath).close()
+            if not os.path.exists(csspath):
+                raise IOError("No such file or directory: '{}'".format(csspath))
         if not hasattr(config, "slaveinput"):
             # prevent opening htmlpath on slave nodes (xdist)
             config._html = HTMLReport(htmlpath, config)

--- a/pytest_html/plugin.py
+++ b/pytest_html/plugin.py
@@ -68,7 +68,7 @@ def pytest_configure(config):
     htmlpath = config.getoption("htmlpath")
     if htmlpath:
         for csspath in config.getoption("css"):
-            open(csspath)
+            open(csspath).close()
         if not hasattr(config, "slaveinput"):
             # prevent opening htmlpath on slave nodes (xdist)
             config._html = HTMLReport(htmlpath, config)

--- a/testing/test_pytest_html.py
+++ b/testing/test_pytest_html.py
@@ -759,7 +759,7 @@ class TestHTML:
         assert re.search(regex_error, html) is not None
 
     @pytest.mark.parametrize("colors", [(["red"]), (["green", "blue"])])
-    def test_css(self, testdir, colors):
+    def test_css(self, testdir, recwarn, colors):
         testdir.makepyfile("def test_pass(): pass")
         css = {}
         cssargs = []
@@ -770,14 +770,16 @@ class TestHTML:
             cssargs.extend(["--css", path])
         result, html = run(testdir, "report.html", "--self-contained-html", *cssargs)
         assert result.ret == 0
+        assert len(recwarn) == 0
         for k, v in css.items():
             assert str(v["path"]) in html
             assert v["style"] in html
 
-    def test_css_invalid(self, testdir):
+    def test_css_invalid(self, testdir, recwarn):
         testdir.makepyfile("def test_pass(): pass")
         result = testdir.runpytest("--html", "report.html", "--css", "style.css")
         assert result.ret
+        assert len(recwarn) == 0
         assert "No such file or directory: 'style.css'" in result.stderr.str()
 
     def test_css_invalid_no_html(self, testdir):


### PR DESCRIPTION
When using custom CSS file I'm getting following warning:

```
/home/nelchael/.local/share/virtualenvs/functional-tests-IjeTcJ7i/lib/python3.7/site-packages/pytest_html/plugin.py:71: ResourceWarning: unclosed file <_io.TextIOWrapper name='resources/pytest-html-custom.css' mode='r' encoding='UTF-8'>
  open(csspath)
ResourceWarning: Enable tracemalloc to get the object allocation traceback
```

This fixes it by closing the opened file. If I'm understanding it correctly, the file is opened just to make sure it exists here, so it could be potentially replaced with `os.access` call, but it's entirely optional.