### PR TITLE
Fix min-width which produced horizontal scrolls

### DIFF
--- a/pytest_html/resources/style.css
+++ b/pytest_html/resources/style.css
@@ -1,7 +1,8 @@
 body {
 	font-family: Helvetica, Arial, sans-serif;
 	font-size: 12px;
-	min-width: 1200px;
+	/* do not increase min-width as some may use split screens */
+	min-width: 800px;
 	color: #999;
 }
 


### PR DESCRIPTION
PRevious min-width caused undesired horizontal scrolls even on a 5K
display with 1/2 split screen. Reduced value allows users to better
use their screens.