### PR TITLE
Trigger sorting for initial sort column

### DIFF
--- a/pytest_html/resources/main.js
+++ b/pytest_html/resources/main.js
@@ -111,7 +111,7 @@ function init () {
 
     show_filters();
 
-    toggle_sort_states(find('.initial-sort'));
+    sort_column(find('.initial-sort'));
 
     find_all('.sortable').forEach(function(elem) {
         elem.addEventListener("click",


### PR DESCRIPTION
Currently it only sets the toggles for initial sort columns without actually doing the sorting.
This fixes https://github.com/pytest-dev/pytest-html/issues/247