### PR TITLE
Video support for mp4 format

### DIFF
--- a/pytest_html/extras.py
+++ b/pytest_html/extras.py
@@ -7,6 +7,7 @@ FORMAT_IMAGE = "image"
 FORMAT_JSON = "json"
 FORMAT_TEXT = "text"
 FORMAT_URL = "url"
+FORMAT_VIDEO = "video"
 
 
 def extra(content, format, name=None, mime_type=None, extension=None):
@@ -49,3 +50,11 @@ def text(content, name="Text"):
 
 def url(content, name="URL"):
     return extra(content, FORMAT_URL, name)
+
+
+def video(content, name="Video", mime_type="video/mp4", extension="mp4"):
+    return extra(content, FORMAT_VIDEO, name, mime_type, extension)
+
+
+def mp4(content, name="Video"):
+    return video(content, name)

--- a/pytest_html/plugin.py
+++ b/pytest_html/plugin.py
@@ -181,33 +181,7 @@ class HTMLReport:
         def append_extra_html(self, extra, extra_index, test_index):
             href = None
             if extra.get("format") == extras.FORMAT_IMAGE:
-                content = extra.get("content")
-                try:
-                    is_uri_or_path = content.startswith(("file", "http")) or isfile(
-                        content
-                    )
-                except ValueError:
-                    # On Windows, os.path.isfile throws this exception when
-                    # passed a b64 encoded image.
-                    is_uri_or_path = False
-                if is_uri_or_path:
-                    if self.self_contained:
-                        warnings.warn(
-                            "Self-contained HTML report "
-                            "includes link to external "
-                            "resource: {}".format(content)
-                        )
-                    html_div = html.a(html.img(src=content), href=content)
-                elif self.self_contained:
-                    src = "data:{};base64,{}".format(extra.get("mime_type"), content)
-                    html_div = html.img(src=src)
-                else:
-                    content = b64decode(content.encode("utf-8"))
-                    href = src = self.create_asset(
-                        content, extra_index, test_index, extra.get("extension"), "wb"
-                    )
-                    html_div = html.a(html.img(src=src), href=href)
-                self.additional_html.append(html.div(html_div, class_="image"))
+                self._append_image(extra, extra_index, test_index)
 
             elif extra.get("format") == extras.FORMAT_HTML:
                 self.additional_html.append(html.div(raw(extra.get("content"))))
@@ -279,8 +253,9 @@ class HTMLReport:
                 log.append("No log output captured.")
             additional_html.append(log)
 
-        def _append_video(self, extra, extra_index, test_index):
-            video_base = '<video controls><source src="{}" type="video/mp4"></video>'
+        def _make_media_html_div(
+            self, extra, extra_index, test_index, base_extra_string, base_extra_class
+        ):
             content = extra.get("content")
             try:
                 is_uri_or_path = content.startswith(("file", "http")) or isfile(content)
@@ -293,20 +268,35 @@ class HTMLReport:
                     warnings.warn(
                         "Self-contained HTML report "
                         "includes link to external "
-                        "resource: {}".format(content)
+                        f"resource: {content}"
                     )
 
-                html_div = html.div(raw(video_base.format(extra.get("content"))))
+                html_div = html.a(
+                    raw(base_extra_string.format(extra.get("content"))), href=content
+                )
             elif self.self_contained:
-                src = "data:{};base64,{}".format(extra.get("mime_type"), content)
-                html_div = html.div(raw(video_base.format(src)))
+                src = f"data:{extra.get('mime_type')};base64,{content}"
+                html_div = raw(base_extra_string.format(src))
             else:
                 content = b64decode(content.encode("utf-8"))
                 href = src = self.create_asset(
                     content, extra_index, test_index, extra.get("extension"), "wb"
                 )
+                html_div = html.a(class_=base_extra_class, target="_blank", href=href)
+            return html_div
 
-                html_div = html.a(video_base.format(src), href=href)
+        def _append_image(self, extra, extra_index, test_index):
+            image_base = '<img src="{}"/>'
+            html_div = self._make_media_html_div(
+                extra, extra_index, test_index, image_base, "image"
+            )
+            self.additional_html.append(html.div(html_div, class_="image"))
+
+        def _append_video(self, extra, extra_index, test_index):
+            video_base = '<video controls><source src="{}" type="video/mp4"></video>'
+            html_div = self._make_media_html_div(
+                extra, extra_index, test_index, video_base, "video"
+            )
             self.additional_html.append(html.div(html_div, class_="video"))
 
     def _appendrow(self, outcome, report):

--- a/pytest_html/resources/style.css
+++ b/pytest_html/resources/style.css
@@ -113,6 +113,19 @@ div.image {
 div.image img {
 	width: 320px
 }
+div.video {
+	border: 1px solid #e6e6e6;
+	float: right;
+	height: 240px;
+	margin-left: 5px;
+	overflow: hidden;
+	width: 320px
+}
+div.video video {
+	overflow: hidden;
+	width: 320px;
+    height: 240px;
+}
 .collapsed {
 	display: none;
 }


### PR DESCRIPTION
# Summary
This feature enables the use of extra videos in the reports in the same way as images are used.
```
extra.video(content, name="Video", mime_type="video/mp4", extension="mp4")
extra.mp4(content, name="Video")
```
## Details
- Videos may be included as reference, or as standalone
- Both of these cases are managed as the images are. Base64 encoding is used to pack the video as standalone data if needed.
- Extra video and windows path for videos are both added to the unit tests.
- Video and images were refactored to use a common media function internally to eliminate code duplication.