### PR TITLE
Added support for ordering metadata dictionaries by key.

### DIFF
--- a/pytest_html/plugin.py
+++ b/pytest_html/plugin.py
@@ -510,7 +510,8 @@ class HTMLReport:
                 key_value_list = [f"'{k}': {value[k]}" for k in sorted(value)]
                 value = ", ".join(key_value_list)
                 value = "{" + value + "}"
-            rows.append(html.tr(html.td(key), html.td(raw(value))))
+            raw_value_string = raw(str(value))
+            rows.append(html.tr(html.td(key), html.td(raw_value_string)))
 
         environment.append(html.table(rows, id="environment"))
         return environment

--- a/pytest_html/plugin.py
+++ b/pytest_html/plugin.py
@@ -530,9 +530,8 @@ class HTMLReport:
             elif isinstance(value, (list, tuple, set)):
                 value = ", ".join(str(i) for i in sorted(map(str, value)))
             elif isinstance(value, dict):
-                key_value_list = [f"'{k}': {value[k]}" for k in sorted(value)]
-                value = ", ".join(key_value_list)
-                value = "{" + value + "}"
+                sorted_dict = {k: value[k] for k in sorted(value)}
+                value = json.dumps(sorted_dict)
             raw_value_string = raw(str(value))
             rows.append(html.tr(html.td(key), html.td(raw_value_string)))
 

--- a/pytest_html/plugin.py
+++ b/pytest_html/plugin.py
@@ -505,8 +505,12 @@ class HTMLReport:
             if isinstance(value, str) and value.startswith("http"):
                 value = html.a(value, href=value, target="_blank")
             elif isinstance(value, (list, tuple, set)):
-                value = ", ".join(str(i) for i in value)
-            rows.append(html.tr(html.td(key), html.td(value)))
+                value = ", ".join(str(i) for i in sorted(map(str, value)))
+            elif isinstance(value, dict):
+                key_value_list = [f"'{k}': {value[k]}" for k in sorted(value)]
+                value = ", ".join(key_value_list)
+                value = "{" + value + "}"
+            rows.append(html.tr(html.td(key), html.td(raw(value))))
 
         environment.append(html.table(rows, id="environment"))
         return environment

--- a/testing/test_pytest_html.py
+++ b/testing/test_pytest_html.py
@@ -692,7 +692,7 @@ class TestHTML:
         result, html = run(testdir)
         assert result.ret == 0
         assert "Environment" in html
-        assert len(re.findall(expected_html_re, html)) == 1, html
+        assert len(re.findall(expected_html_re, html)) == 1
 
     _unordered_dict = {k: len(k) for k in _unsorted_tuples[0]}
     _unordered_dict_expected = (
@@ -732,7 +732,7 @@ class TestHTML:
         result, html = run(testdir)
         assert result.ret == 0
         assert "Environment" in html
-        assert len(re.findall(expected_output, html)) == 1, html
+        assert len(re.findall(expected_output, html)) == 1
 
     def test_environment_ordered(self, testdir):
         testdir.makeconftest(


### PR DESCRIPTION
# Summary
This pull request fixes #245 by sorting environment metadata dictionaries by keys.

## Limitations

- This fix does not implement any form of recursion. This means that if you have a metadata value which has a dictionnary value, this inner dictionary will not be sorted.
- In order to be able to compare the dictionary key values, they are cast as string. This allows a lexical sorting order, which is a natural way of sorting.