### PR TITLE
Fix collapsable bug

### DIFF
--- a/pytest_html/plugin.py
+++ b/pytest_html/plugin.py
@@ -143,12 +143,13 @@ class HTMLReport:
             )
 
             if len(cells) > 0:
-                td_class = "extra"
+                tr_class = None
                 if self.config.getini("render_collapsed"):
-                    td_class += " collapsed"
+                    tr_class = "collapsed"
                 self.row_table = html.tr(cells)
                 self.row_extra = html.tr(
-                    html.td(self.additional_html, class_=td_class, colspan=len(cells))
+                    html.td(self.additional_html, class_="extra", colspan=len(cells)),
+                    class_=tr_class,
                 )
 
         def __lt__(self, other):

--- a/pytest_html/resources/main.js
+++ b/pytest_html/resources/main.js
@@ -81,7 +81,9 @@ function add_collapse() {
         var collapsed = get_query_parameter('collapsed') || 'Passed';
         var extras = elem.parentNode.nextElementSibling;
         var expandcollapse = document.createElement("span");
-        if (collapsed.includes(elem.innerHTML)) {
+        if (extras.classList.contains("collapsed")) {
+            expandcollapse.classList.add("expander")
+        } else if (collapsed.includes(elem.innerHTML)) {
             extras.classList.add("collapsed");
             expandcollapse.classList.add("expander");
         } else {


### PR DESCRIPTION
Fixes #239 (again)

Had placed the `collapsed` class in the wrong tag.

Which in the end was a good thing since I discovered that JS needed an update as well to display the correct CSS (show/hide text).