### PR TITLE
Add extra fixture

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -192,6 +192,17 @@ created hyper link:
 
     extra.append(pytest_html.extras.text('some string', name='Different title'))
 
+It is also possible to use the fixture :code:`extra` to add content directly
+in a test function without implementing hooks. These will generally end up
+before any extras added by plugins.
+
+.. code-block:: python
+
+   from pytest_html import extras
+
+   def test_extra(extra):
+      extra.append(extras.text('some string'))
+
 
 Modifying the results table
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/testing/test_pytest_html.py
+++ b/testing/test_pytest_html.py
@@ -583,6 +583,20 @@ class TestHTML:
         assert link in html
         assert os.path.exists(src)
 
+    def test_extra_fixture(self, testdir):
+        content = b64encode(b"foo").decode("ascii")
+        testdir.makepyfile(
+            f"""
+            def test_pass(extra):
+                from pytest_html import extras
+                extra.append(extras.png('{content}'))
+        """
+        )
+        result, html = run(testdir, "report.html", "--self-contained-html")
+        assert result.ret == 0
+        src = f"data:image/png;base64,{content}"
+        assert f'<img src="{src}"/>' in html
+
     def test_no_invalid_characters_in_filename(self, testdir):
         testdir.makeconftest(
             """


### PR DESCRIPTION
Adds a fixture, `extra`, which can be used to add extra content directly in a test function without having to implement hooks.