### PR TITLE
Add hook to change report main title

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -87,6 +87,19 @@ be used to change the appearance of the report.
 
   $ pytest --html=report.html --css=highcontrast.css --css=accessible.css
 
+Report Title
+~~~~~~~~~~~~
+
+By default report title will be the filename of the report, you can edit it by using the :code: `pytest_html_report_title` hook:
+
+.. code-block:: python
+
+   import pytest
+   from py.xml import html
+
+   def pytest_html_report_title(report)
+      report.title = "My very own title!"
+
 Environment
 ~~~~~~~~~~~
 

--- a/pytest_html/hooks.py
+++ b/pytest_html/hooks.py
@@ -3,6 +3,10 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
+def pytest_html_report_title(report):
+    """ Called before adding the title to the report """
+
+
 def pytest_html_results_summary(prefix, summary, postfix):
     """ Called before adding the summary section to the report """
 

--- a/pytest_html/plugin.py
+++ b/pytest_html/plugin.py
@@ -99,6 +99,7 @@ class HTMLReport:
         logfile = os.path.expanduser(os.path.expandvars(logfile))
         self.logfile = os.path.abspath(logfile)
         self.test_logs = []
+        self.title = os.path.basename(self.logfile)
         self.results = []
         self.errors = self.failed = 0
         self.passed = self.skipped = 0
@@ -490,9 +491,11 @@ class HTMLReport:
             __name__, os.path.join("resources", "main.js")
         ).decode("utf-8")
 
+        session.config.hook.pytest_html_report_title(report=self)
+
         body = html.body(
             html.script(raw(main_js)),
-            html.h1(os.path.basename(self.logfile)),
+            html.h1(self.title),
             html.p(
                 "Report generated on {} at {} by ".format(
                     generated.strftime("%d-%b-%Y"), generated.strftime("%H:%M:%S")

--- a/testing/test_pytest_html.py
+++ b/testing/test_pytest_html.py
@@ -904,3 +904,19 @@ class TestHTML:
         assert result.ret == 1
         assert len(re.findall(collapsed_html, html)) == expected_count
         assert_results(html, tests=2, passed=1, failed=1)
+
+    def test_custom_content_report_title(self, testdir):
+        content_report_title = str(random.random())
+        testdir.makeconftest(
+            f"""
+            import pytest
+            from py.xml import html
+
+            def pytest_html_report_title(report):
+                report.title = "title is {content_report_title}"
+        """
+        )
+        testdir.makepyfile("def test_pass(): pass")
+        result, html = run(testdir)
+        assert result.ret == 0
+        assert len(re.findall(content_report_title, html)) == 1


### PR DESCRIPTION
I think it is a good thing to be able to have a customizable report title that is not always the same as the file name.

As it is my first merge request on this project I'm open to any comment.