### PR TITLE
Post process html to include teardown in log

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,10 @@ Release Notes
 
   * Thanks to `@Zac-HD <https://github.com/Zac-HD>`_ for the fix
 
+* Post process HTML generation to allow teardown to appear in the HTML output. (`#131 <https://github.com/pytest-dev/pytest-html/issues/131>`_)
+
+  * Thanks to `@iwanb <https://github.com/iwanb>`_ for reporting and `@csm10495 <https://github.com/csm10495>`_ for the fix
+
 **2.1.1 (2020-03-18)**
 
 * Fix issue with funcargs causing failures. (`#282 <https://github.com/pytest-dev/pytest-html/issues/282>`_)


### PR DESCRIPTION
I believe this would resolve #131 ... however it isn't really optimal, I didn't want to dig into the html logic, so instead just moved it to be post processed and tried to coerce the test result into what the existing code seemed to want.
