### PR TITLE
Fix image missing when using Base64 content

### DIFF
--- a/pytest_html/plugin.py
+++ b/pytest_html/plugin.py
@@ -319,7 +319,12 @@ class HTMLReport:
                 href = src = self.create_asset(
                     content, extra_index, test_index, extra.get("extension"), "wb"
                 )
-                html_div = html.a(class_=base_extra_class, target="_blank", href=href)
+                html_div = html.a(
+                    raw(base_extra_string.format(src)),
+                    class_=base_extra_class,
+                    target="_blank",
+                    href=href,
+                )
             return html_div
 
         def _append_image(self, extra, extra_index, test_index):

--- a/testing/test_pytest_html.py
+++ b/testing/test_pytest_html.py
@@ -510,7 +510,9 @@ class TestHTML:
         assert result.ret == 0
         src = f"assets/test_extra_image_separated.py__test_pass_0_0.{file_extension}"
         link = f'<a class="image" href="{src}" target="_blank">'
+        img = f'<img src="{src}"/>'
         assert link in html
+        assert img in html
         assert os.path.exists(src)
 
     @pytest.mark.parametrize(
@@ -544,8 +546,10 @@ class TestHTML:
             asset_name = "test_extra_image_separated_rerun.py__test_fail"
             src = f"assets/{asset_name}_0_{i}.{file_extension}"
             link = f'<a class="image" href="{src}" target="_blank">'
+            img = f'<img src="{src}"/>'
             assert result.ret
             assert link in html
+            assert img in html
             assert os.path.exists(src)
 
     @pytest.mark.parametrize("src_type", ["https://", "file://", "image.png"])


### PR DESCRIPTION
When adding a Base64 encoded image to a non-self contained report, only an empty link is created but no image.