### PR TITLE
Add download tag for self contained html

### DIFF
--- a/pytest_html/plugin.py
+++ b/pytest_html/plugin.py
@@ -227,7 +227,7 @@ class HTMLReport:
                 content = json.dumps(extra.get("content"))
                 if self.self_contained:
                     href = data_uri(content, mime_type=extra.get("mime_type"))
-                    download = extra.get("name")
+                    download = extra.get("name") + '.json'
                 else:
                     href = self.create_asset(
                         content, extra_index, test_index, extra.get("extension")
@@ -239,7 +239,7 @@ class HTMLReport:
                     content = content.decode("utf-8")
                 if self.self_contained:
                     href = data_uri(content)
-                    download = extra.get("name")
+                    download = extra.get("name") + '.txt'
                 else:
                     href = self.create_asset(
                         content, extra_index, test_index, extra.get("extension")
@@ -252,13 +252,19 @@ class HTMLReport:
                 self._append_video(extra, extra_index, test_index)
 
             if href is not None:
+                kwargs = {
+                    "class_" : extra.get("format"),
+                    "href" : href,
+                    "target" : "_blank",
+                }
+
+                if download:
+                    kwargs['download'] = download
+
                 self.links_html.append(
                     html.a(
                         extra.get("name"),
-                        class_=extra.get("format"),
-                        href=href,
-                        target="_blank",
-                        download=download,
+                        **kwargs
                     )
                 )
                 self.links_html.append(" ")

--- a/pytest_html/plugin.py
+++ b/pytest_html/plugin.py
@@ -227,7 +227,7 @@ class HTMLReport:
                 content = json.dumps(extra.get("content"))
                 if self.self_contained:
                     href = data_uri(content, mime_type=extra.get("mime_type"))
-                    download = extra.get("name") + '.json'
+                    download = extra.get("name") + ".json"
                 else:
                     href = self.create_asset(
                         content, extra_index, test_index, extra.get("extension")
@@ -239,7 +239,7 @@ class HTMLReport:
                     content = content.decode("utf-8")
                 if self.self_contained:
                     href = data_uri(content)
-                    download = extra.get("name") + '.txt'
+                    download = extra.get("name") + ".txt"
                 else:
                     href = self.create_asset(
                         content, extra_index, test_index, extra.get("extension")

--- a/pytest_html/plugin.py
+++ b/pytest_html/plugin.py
@@ -215,6 +215,8 @@ class HTMLReport:
 
         def append_extra_html(self, extra, extra_index, test_index):
             href = None
+            download = None
+
             if extra.get("format") == extras.FORMAT_IMAGE:
                 self._append_image(extra, extra_index, test_index)
 
@@ -225,6 +227,7 @@ class HTMLReport:
                 content = json.dumps(extra.get("content"))
                 if self.self_contained:
                     href = data_uri(content, mime_type=extra.get("mime_type"))
+                    download = extra.get("name")
                 else:
                     href = self.create_asset(
                         content, extra_index, test_index, extra.get("extension")
@@ -236,6 +239,7 @@ class HTMLReport:
                     content = content.decode("utf-8")
                 if self.self_contained:
                     href = data_uri(content)
+                    download = extra.get("name")
                 else:
                     href = self.create_asset(
                         content, extra_index, test_index, extra.get("extension")
@@ -254,6 +258,7 @@ class HTMLReport:
                         class_=extra.get("format"),
                         href=href,
                         target="_blank",
+                        download=download
                     )
                 )
                 self.links_html.append(" ")

--- a/pytest_html/plugin.py
+++ b/pytest_html/plugin.py
@@ -253,20 +253,15 @@ class HTMLReport:
 
             if href is not None:
                 kwargs = {
-                    "class_" : extra.get("format"),
-                    "href" : href,
-                    "target" : "_blank",
+                    "class_": extra.get("format"),
+                    "href": href,
+                    "target": "_blank",
                 }
 
                 if download:
-                    kwargs['download'] = download
+                    kwargs["download"] = download
 
-                self.links_html.append(
-                    html.a(
-                        extra.get("name"),
-                        **kwargs
-                    )
-                )
+                self.links_html.append(html.a(extra.get("name"), **kwargs))
                 self.links_html.append(" ")
 
         def append_log_html(self, report, additional_html):

--- a/pytest_html/plugin.py
+++ b/pytest_html/plugin.py
@@ -258,7 +258,7 @@ class HTMLReport:
                         class_=extra.get("format"),
                         href=href,
                         target="_blank",
-                        download=download
+                        download=download,
                     )
                 )
                 self.links_html.append(" ")

--- a/testing/test_pytest_html.py
+++ b/testing/test_pytest_html.py
@@ -947,7 +947,7 @@ href="{href}" target="_blank">JSON</a>'
         )
         result, html = run(testdir, "report.html", "--self-contained-html")
         assert result.ret == 0
-        assert "download=\"TextFileName.txt\""in html
+        assert 'download="TextFileName.txt"' in html
 
     def test_custom_self_contained_json_file_name(self, testdir):
         testdir.makepyfile(
@@ -959,4 +959,4 @@ href="{href}" target="_blank">JSON</a>'
         )
         result, html = run(testdir, "report.html", "--self-contained-html")
         assert result.ret == 0
-        assert "download=\"JsonFileName.json\""in html
+        assert 'download="JsonFileName.json"' in html

--- a/testing/test_pytest_html.py
+++ b/testing/test_pytest_html.py
@@ -337,7 +337,8 @@ class TestHTML:
         result, html = run(testdir, "report.html", "--self-contained-html")
         assert result.ret == 0
         href = f"data:text/plain;charset=utf-8;base64,{encoded}"
-        link = f'<a class="text" download="Text.txt" href="{href}" target="_blank">Text</a>'
+        link = f'<a class="text" download="Text.txt" \
+href="{href}" target="_blank">Text</a>'
         assert link in html
 
     def test_extra_json(self, testdir):
@@ -360,7 +361,8 @@ class TestHTML:
         content_str = json.dumps(content)
         data = b64encode(content_str.encode("utf-8")).decode("ascii")
         href = f"data:application/json;charset=utf-8;base64,{data}"
-        link = f'<a class="json" download="JSON.json" href="{href}" target="_blank">JSON</a>'
+        link = f'<a class="json" download="JSON.json" \
+href="{href}" target="_blank">JSON</a>'
         assert link in html
 
     def test_extra_url(self, testdir):

--- a/testing/test_pytest_html.py
+++ b/testing/test_pytest_html.py
@@ -936,3 +936,27 @@ href="{href}" target="_blank">JSON</a>'
         result, html = run(testdir)
         assert result.ret == 0
         assert len(re.findall(content_report_title, html)) == 1
+
+    def test_custom_self_contained_text_file_name(self, testdir):
+        testdir.makepyfile(
+            """
+            from pytest_html import extras
+            def test_pass(extra):
+                extra.append(extras.text("Hello Text!", "TextFileName"))
+        """
+        )
+        result, html = run(testdir, "report.html", "--self-contained-html")
+        assert result.ret == 0
+        assert "download=\"TextFileName.txt\""in html
+
+    def test_custom_self_contained_json_file_name(self, testdir):
+        testdir.makepyfile(
+            """
+            from pytest_html import extras
+            def test_pass(extra):
+                extra.append(extras.json(dict(), "JsonFileName"))
+        """
+        )
+        result, html = run(testdir, "report.html", "--self-contained-html")
+        assert result.ret == 0
+        assert "download=\"JsonFileName.json\""in html

--- a/testing/test_pytest_html.py
+++ b/testing/test_pytest_html.py
@@ -337,7 +337,7 @@ class TestHTML:
         result, html = run(testdir, "report.html", "--self-contained-html")
         assert result.ret == 0
         href = f"data:text/plain;charset=utf-8;base64,{encoded}"
-        link = f'<a class="text" href="{href}" target="_blank">Text</a>'
+        link = f'<a class="text" download="Text.txt" href="{href}" target="_blank">Text</a>'
         assert link in html
 
     def test_extra_json(self, testdir):
@@ -360,7 +360,7 @@ class TestHTML:
         content_str = json.dumps(content)
         data = b64encode(content_str.encode("utf-8")).decode("ascii")
         href = f"data:application/json;charset=utf-8;base64,{data}"
-        link = f'<a class="json" href="{href}" target="_blank">JSON</a>'
+        link = f'<a class="json" download="JSON.json" href="{href}" target="_blank">JSON</a>'
         assert link in html
 
     def test_extra_url(self, testdir):


### PR DESCRIPTION
This should resolve #273. If we're working with a self contained html, simply download text (and json) files instead of trying to open them in the current browser window.