### PR TITLE
Add missing image/video tag

### DIFF
--- a/pytest_html/plugin.py
+++ b/pytest_html/plugin.py
@@ -321,7 +321,9 @@ class HTMLReport:
                 )
                 html_div = html.a(
                     raw(base_extra_string.format(href)),
-                    class_=base_extra_class, target="_blank", href=href
+                    class_=base_extra_class, 
+                    target="_blank", 
+                    href=href
                 )
             return html_div
 

--- a/pytest_html/plugin.py
+++ b/pytest_html/plugin.py
@@ -319,7 +319,10 @@ class HTMLReport:
                 href = src = self.create_asset(
                     content, extra_index, test_index, extra.get("extension"), "wb"
                 )
-                html_div = html.a(class_=base_extra_class, target="_blank", href=href)
+                html_div = html.a(
+                    raw(base_extra_string.format(href)),
+                    class_=base_extra_class, target="_blank", href=href
+                )
             return html_div
 
         def _append_image(self, extra, extra_index, test_index):


### PR DESCRIPTION
For image/video attachments that are not added as files, the non-self-contained html report does not show the image next to the test log as expected.  The div and link where the image/video goes is created, but no image or video element is inserted.