### PR TITLE
Use pytest-html when running its own tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ deps =
     pytest-rerunfailures
     pytest-mock
     py{36,37,py3}-ansi2html: ansi2html
-commands = pytest -v -r a {posargs}
+commands = pytest -v -r a --color=yes --html={envlogdir}/report.html --self-contained-html {posargs}
 
 [testenv:linting]
 skip_install = True


### PR DESCRIPTION
It does enable pytest-html reporting on its own test runs, so we
can easily see the outcome of the testing. This will also allow
publishing the results on CI/CD pipelines.

Reports are generated in the same location as tox logs, so they
do not overlap.