### PR TITLE
Fix embedded images (and videos)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Release Notes
 -------------
 
+**2.1.2 (unreleased)**
+
+* Fix issue with missing image or video in extras. (`#265 <https://github.com/pytest-dev/pytest-html/issues/265>`_ and `pytest-selenium#237 <https://github.com/pytest-dev/pytest-selenium/issues/237>`_)
+
+  * Thanks to `@p00j4 <https://github.com/p00j4>`_ and `@anothermattbrown <https://github.com/anothermattbrown>`_ for reporting and `@christiansandberg <https://github.com/christiansandberg>`_ and `@superdodd <https://github.com/superdodd>`_ and `@dhalperi <https://github.com/dhalperi>`_ for the fix
+
 **2.1.1 (2020-03-18)**
 
 * Fix issue with funcargs causing failures. (`#282 <https://github.com/pytest-dev/pytest-html/issues/282>`_)

--- a/testing/test_pytest_html.py
+++ b/testing/test_pytest_html.py
@@ -591,8 +591,10 @@ class TestHTML:
         file_name = f"test_very_long_test_name.py__{test_name}_0_0.png"[-255:]
         src = "assets/" + file_name
         link = f'<a class="image" href="{src}" target="_blank">'
+        img = f'<img src="{src}"/>'
         assert result.ret
         assert link in html
+        assert img in html
         assert os.path.exists(src)
 
     def test_extra_fixture(self, testdir):


### PR DESCRIPTION
See #265 and related pytest-dev/pytest-selenium#237.

In #260, one of the three paths through the new `_make_media_html_div` lost the ability to embed its inner content. This PR adds tests for that (first commit, they failed) and adds back the embedding (second commit).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pytest-dev/pytest-html/298)
<!-- Reviewable:end -->
