### PR TITLE
Update link to Tox

### DIFF
--- a/development.rst
+++ b/development.rst
@@ -38,7 +38,7 @@ You can do this with `git commit --allow-empty`
 Running Tests
 -------------
 
-You will need `Tox <http://tox.testrun.org/>`_ installed to run the tests
+You will need `Tox <https://tox.readthedocs.io>`_ installed to run the tests
 against the supported Python versions. If you're using `Pipenv`_ it will be
 installed for you.
 


### PR DESCRIPTION
The link to `Tox` was pointing to what Firefox deemed a potential security risk. This PR updates the link to `Tox` to point to its readthedocs page

See https://github.com/pytest-dev/pytest-html/issues/300