### PR TITLE
Customizable html output structure

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -259,6 +259,27 @@ additional HTML and log output with a notice that the log is empty:
           del data[:]
           data.append(html.div('No log output captured.', class_='empty log'))
 
+Modifying the whole test document
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Finally, for major customizations, you may manipulate and update the resulting
+html document prior to finalization by hooking :code:`pytest_html_report_final_dom`.
+
+.. code-block:: python
+
+  import pytest
+
+  def pytest_html_report_final_dom(document):
+      from importlib.resources import read_text
+      js = read_text(".", "fancy.js")
+      for node in list(iter(document)):
+          if isinstance(node, html.head):
+             node.extend([html.script(raw(js), type="text/javascript")])
+
+
+
+
+
 Display options
 ---------------
 

--- a/README.rst
+++ b/README.rst
@@ -269,7 +269,8 @@ html document prior to finalization by hooking :code:`pytest_html_report_final_d
 
   import pytest
 
-  def pytest_html_report_final_dom(document):
+  def pytest_html_report_final_dom(session, document):
+      # session is a `_pytest.main.Session` object
       from importlib.resources import read_text
       js = read_text(".", "fancy.js")
       for node in list(iter(document)):

--- a/pytest_html/hooks.py
+++ b/pytest_html/hooks.py
@@ -2,8 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from py.xml import html
-
 
 def pytest_html_report_title(report):
     """ Called before adding the title to the report """
@@ -25,5 +23,5 @@ def pytest_html_results_table_html(report, data):
     """ Called after building results table additional HTML. """
 
 
-def pytest_html_report_final_dom(document: html.html):
+def pytest_html_report_final_dom(document):
     """ Called after the entire document has been created. """

--- a/pytest_html/hooks.py
+++ b/pytest_html/hooks.py
@@ -2,6 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+from py.xml import html
+
 
 def pytest_html_report_title(report):
     """ Called before adding the title to the report """
@@ -21,3 +23,7 @@ def pytest_html_results_table_row(report, cells):
 
 def pytest_html_results_table_html(report, data):
     """ Called after building results table additional HTML. """
+
+
+def pytest_html_report_final_dom(document: html.html):
+    """ Called after the entire document has been created. """

--- a/pytest_html/hooks.py
+++ b/pytest_html/hooks.py
@@ -23,5 +23,5 @@ def pytest_html_results_table_html(report, data):
     """ Called after building results table additional HTML. """
 
 
-def pytest_html_report_final_dom(document):
+def pytest_html_report_final_dom(session, document):
     """ Called after the entire document has been created. """

--- a/pytest_html/plugin.py
+++ b/pytest_html/plugin.py
@@ -524,28 +524,37 @@ class HTMLReport:
 
         session.config.hook.pytest_html_report_title(report=self)
 
-        body = html.body(
-            html.script(raw(main_js)),
-            html.h1(self.title),
-            html.p(
-                "Report generated on {} at {} by ".format(
-                    generated.strftime("%d-%b-%Y"), generated.strftime("%H:%M:%S")
-                ),
-                html.a("pytest-html", href=__pypi_url__),
-                f" v{__version__}",
-            ),
-            onLoad="init()",
-        )
-
-        body.extend(self._generate_environment(session.config))
-
         summary_prefix, summary_postfix = [], []
         session.config.hook.pytest_html_results_summary(
             prefix=summary_prefix, summary=summary, postfix=summary_postfix
         )
-        body.extend([html.h2("Summary")] + summary_prefix + summary + summary_postfix)
+        summary = [html.h2("Summary"), *summary_prefix, *summary, *summary_postfix]
 
-        body.extend(results)
+        body = html.body(
+            html.script(raw(main_js)),
+            html.div(
+                html.div(
+                    html.h1(self.title),
+                    html.p(
+                        "Report generated on {} at {} by ".format(
+                            generated.strftime("%d-%b-%Y"),
+                            generated.strftime("%H:%M:%S"),
+                        ),
+                        html.a("pytest-html", href=__pypi_url__),
+                        f" v{__version__}",
+                    ),
+                    html.div(
+                        *self._generate_environment(session.config),
+                        class_="content-environment",
+                    ),
+                    html.div(*summary, class_="content-summary"),
+                    class_="content-header",
+                ),
+                html.div(*results, class_="content-results", id="results-container"),
+                class_="content",
+            ),
+            onLoad="init()",
+        )
 
         doc = html.html(head, body)
 

--- a/pytest_html/plugin.py
+++ b/pytest_html/plugin.py
@@ -558,7 +558,7 @@ class HTMLReport:
 
         doc = html.html(head, body)
 
-        session.config.hook.pytest_html_report_final_dom(document=doc)
+        session.config.hook.pytest_html_report_final_dom(session=session, document=doc)
 
         unicode_doc = "<!DOCTYPE html>\n{}".format(doc.unicode(indent=2))
 

--- a/pytest_html/plugin.py
+++ b/pytest_html/plugin.py
@@ -558,6 +558,8 @@ class HTMLReport:
 
         doc = html.html(head, body)
 
+        session.config.hook.pytest_html_report_final_dom(document=doc)
+
         unicode_doc = "<!DOCTYPE html>\n{}".format(doc.unicode(indent=2))
 
         # Fix encoding issues, e.g. with surrogates

--- a/pytest_html/resources/main.js
+++ b/pytest_html/resources/main.js
@@ -139,7 +139,7 @@ function sort_table(clicked, key_func) {
     sorted_rows.forEach(function(elem) {
         parent.appendChild(elem);
     });
-    document.getElementsByTagName("BODY")[0].appendChild(parent);
+    document.getElementById("results-container").appendChild(parent);
 }
 
 function sort(items, key_func, reversed) {

--- a/testing/js_test_report.html
+++ b/testing/js_test_report.html
@@ -14,51 +14,53 @@
   <script src="test.js"></script>
   <script src="../pytest_html/resources/main.js" data-cover></script>
   <div id="qunit-fixture">
-    <table id="results-table">
-      <thead id="results-table-head">
-        <tr>
-          <th class="sortable result initial-sort" col="result">Result</th>
-          <th class="sortable" col="name">Test</th>
-          <th class="sortable numeric" col="duration">Duration</th>
-          <th>Links</th></tr>
-        <tr hidden="true" id="not-found-message">
-          <th colspan="5">No results found. Try to check the filters</th>
-        </tr>
-      </thead>
-      <tbody class="rerun results-table-row">
-        <tr>
-          <td class="col-result">Rerun</td>
-          <td class="test-1 col-name">rerun.py::test_rexample_1</td>
-          <td class="col-duration">1.00</td>
-          <td class="col-links"></td></tr>
-        <tr>
-          <td class="extra" colspan="5">
-            <div class="log">@pytest.mark.flaky(reruns=5)<br/>    def test_example():<br/>        import random<br/>&gt;       assert random.choice([True, False])<br/><span class="error">E       assert False</span><br/><span class="error">E        +  where False = &lt;bound method Random.choice of &lt;random.Random object at 0x7fe80b85f420&gt;&gt;([True, False])</span><br/><span class="error">E        +    where &lt;bound method Random.choice of &lt;random.Random object at 0x7fe80b85f420&gt;&gt; = &lt;module 'random' from '/usr/local/Cellar/python/2.7.12/Frameworks/Python.framework/Versions/2.7/lib/python2.7/random.pyc'&gt;.choice</span><br/><br/>rerun.py:6: AssertionError<br/></div></td></tr></tbody>
-      <tbody class="passed results-table-row">
-        <tr>
-          <td class="col-result">Passed</td>
-          <td class="test-2 col-name">rerun.py::test_example_2</td>
-          <td class="col-duration">0.00</td>
-          <td class="col-links"></td></tr>
-        <tr>
-          <td class="extra" colspan="5">
-            <div class="empty log">No log output captured.</div>
-          </td>
-        </tr>
-      </tbody>
-      <tbody class="passed results-table-row">
-        <tr>
-          <td class="col-result">Passed</td>
-          <td class="test-3 col-name">rerun.py::test_example_3</td>
-          <td class="col-duration">0.00</td>
-          <td class="col-links"></td></tr>
-        <tr>
-          <td class="extra" colspan="5">
-            <div class="empty log">No log output captured.</div>
-          </td>
-        </tr>
-      </tbody>
-    </table>
-  </div>
+     <div id="results-container">
+        <table id="results-table">
+          <thead id="results-table-head">
+            <tr>
+              <th class="sortable result initial-sort" col="result">Result</th>
+              <th class="sortable" col="name">Test</th>
+              <th class="sortable numeric" col="duration">Duration</th>
+              <th>Links</th></tr>
+            <tr hidden="true" id="not-found-message">
+              <th colspan="5">No results found. Try to check the filters</th>
+            </tr>
+          </thead>
+          <tbody class="rerun results-table-row">
+            <tr>
+              <td class="col-result">Rerun</td>
+              <td class="test-1 col-name">rerun.py::test_rexample_1</td>
+              <td class="col-duration">1.00</td>
+              <td class="col-links"></td></tr>
+            <tr>
+              <td class="extra" colspan="5">
+                <div class="log">@pytest.mark.flaky(reruns=5)<br/>    def test_example():<br/>        import random<br/>&gt;       assert random.choice([True, False])<br/><span class="error">E       assert False</span><br/><span class="error">E        +  where False = &lt;bound method Random.choice of &lt;random.Random object at 0x7fe80b85f420&gt;&gt;([True, False])</span><br/><span class="error">E        +    where &lt;bound method Random.choice of &lt;random.Random object at 0x7fe80b85f420&gt;&gt; = &lt;module 'random' from '/usr/local/Cellar/python/2.7.12/Frameworks/Python.framework/Versions/2.7/lib/python2.7/random.pyc'&gt;.choice</span><br/><br/>rerun.py:6: AssertionError<br/></div></td></tr></tbody>
+          <tbody class="passed results-table-row">
+            <tr>
+              <td class="col-result">Passed</td>
+              <td class="test-2 col-name">rerun.py::test_example_2</td>
+              <td class="col-duration">0.00</td>
+              <td class="col-links"></td></tr>
+            <tr>
+              <td class="extra" colspan="5">
+                <div class="empty log">No log output captured.</div>
+              </td>
+            </tr>
+          </tbody>
+          <tbody class="passed results-table-row">
+            <tr>
+              <td class="col-result">Passed</td>
+              <td class="test-3 col-name">rerun.py::test_example_3</td>
+              <td class="col-duration">0.00</td>
+              <td class="col-links"></td></tr>
+            <tr>
+              <td class="extra" colspan="5">
+                <div class="empty log">No log output captured.</div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+     </div>
+   </div>
 </body>
 </html>


### PR DESCRIPTION
Following up on #310, I've made a basic modification to the html structure and how it is generated.

I also added a new hook called `pytest_html_report_final_dom`, the semantics of which are fairly straightforward. 

Commit e8bd795 in itself would be sufficient for addressesing issue #310. Commit 8c97045 is an added bonus to make life easier.

I would also recommend that perhaps in the future, a migration away from `py.xml.html` might be beneficial (in favor of core python libraries that support native tree walking etc). The [py](https://github.com/pytest-dev/py) package is noted as being in maintenance mode and new projects are recommended not to be started using that library. 

Given that the changes required to upgrade `pytest-html` are actually somewhat limited, it might be a good migration target for the future.

Please let me know if or how I should amend this PR to meet project guidelines.