### PR TITLE
Make the maximum asset filename length configurable.

### DIFF
--- a/pytest_html/plugin.py
+++ b/pytest_html/plugin.py
@@ -69,6 +69,12 @@ def pytest_addoption(parser):
         default=False,
         help="Open the report with all rows collapsed. Useful for very large reports",
     )
+    parser.addini(
+        "max_asset_filename_length",
+        default=255,
+        help="set the maximum filename length for assets "
+        "attached to the html report.",
+    )
 
 
 def pytest_configure(config):
@@ -145,6 +151,9 @@ class HTMLReport:
             self.additional_html = []
             self.links_html = []
             self.self_contained = config.getoption("self_contained_html")
+            self.max_asset_filename_length = int(
+                config.getini("max_asset_filename_length")
+            )
             self.logfile = logfile
             self.config = config
             self.row_table = self.row_extra = None
@@ -194,13 +203,12 @@ class HTMLReport:
         def create_asset(
             self, content, extra_index, test_index, file_extension, mode="w"
         ):
-            # 255 is the common max filename length on various filesystems
             asset_file_name = "{}_{}_{}.{}".format(
                 re.sub(r"[^\w\.]", "_", self.test_id),
                 str(extra_index),
                 str(test_index),
                 file_extension,
-            )[-255:]
+            )[-self.max_asset_filename_length :]
             asset_path = os.path.join(
                 os.path.dirname(self.logfile), "assets", asset_file_name
             )

--- a/testing/test_pytest_html.py
+++ b/testing/test_pytest_html.py
@@ -566,7 +566,8 @@ class TestHTML:
         assert result.ret == 0
         assert '<a href="{0}"><img src="{0}"/>'.format(content) in html
 
-    def test_very_long_test_name(self, testdir):
+    @pytest.mark.parametrize("max_asset_filename_length", [10, 100])
+    def test_very_long_test_name(self, testdir, max_asset_filename_length):
         testdir.makeconftest(
             """
             import pytest
@@ -587,8 +588,16 @@ class TestHTML:
                 assert False
         """
         )
-        result, html = run(testdir)
-        file_name = f"test_very_long_test_name.py__{test_name}_0_0.png"[-255:]
+        testdir.makeini(
+            f"""
+            [pytest]
+            max_asset_filename_length = {max_asset_filename_length}
+        """
+        )
+        result, html = run(testdir, "report.html")
+        file_name = f"test_very_long_test_name.py__{test_name}_0_0.png"[
+            -max_asset_filename_length:
+        ]
         src = "assets/" + file_name
         link = f'<a class="image" href="{src}" target="_blank">'
         img = f'<img src="{src}"/>'

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,7 @@ commands = pre-commit run --all-files --show-diff-on-failure
 [flake8]
 max-line-length = 88
 exclude = .eggs,.tox
+ignore = E203
 
 [pytest]
 testpaths = testing


### PR DESCRIPTION
Some filesystems do not support filenames that are 255 characters long. Notably, [aufs](https://en.wikipedia.org/wiki/Aufs) used by CircleCI only supports filenames up to 242 characters.
By making this a configurable option, we allow users to set their desired length limit.