### PR TITLE
Avoid pytest 6.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     package_data={"pytest_html": ["resources/*"]},
     entry_points={"pytest11": ["html = pytest_html.plugin"]},
     setup_requires=["setuptools_scm"],
-    install_requires=["pytest>=5.0", "pytest-metadata"],
+    install_requires=["pytest>=5.0,!=6.0.0", "pytest-metadata"],
     license="Mozilla Public License 2.0 (MPL 2.0)",
     keywords="py.test pytest html report",
     python_requires=">=3.6",


### PR DESCRIPTION
Avoid incompatibility issues caused by https://github.com/pytest-dev/pytest/issues/7559

We only avoid 6.0.0 because a fix will be included in 6.0.1