### PR TITLE
Enable devel testing job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,12 @@ jobs:
       env: TOXENV=py37-ansi2html
 
     -
+      python: 3.8
+      dist: xenial
+      sudo: required
+      env: TOXENV=devel
+
+    -
       python: pypy3
       env: TOXENV=pypy3
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,11 @@
 language: python
 jobs:
+  allow_failures:
+    - name: devel
+      python: 3.8
+      dist: xenial
+      env: TOXENV=devel
+
   include:
     - stage: tests
       language: node_js
@@ -37,10 +43,9 @@ jobs:
       sudo: required
       env: TOXENV=py37-ansi2html
 
-    -
+    - name: devel
       python: 3.8
       dist: xenial
-      sudo: required
       env: TOXENV=devel
 
     -

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,14 @@ basepython = python3
 deps = pre-commit
 commands = pre-commit run --all-files --show-diff-on-failure
 
+[testenv:devel]
+description = Tests with unreleased deps
+basepython = python3
+pip_pre = True
+deps =
+    {[testenv]deps}
+    pytest @ git+https://github.com/pytest-dev/pytest.git
+
 [flake8]
 max-line-length = 88
 exclude = .eggs,.tox


### PR DESCRIPTION
Start testing pytest with code from pytest master and with prereleases of other dependencies, allowing us to detect breakages before upstream releases are made.

This change needs https://github.com/pytest-dev/pytest-html/pull/319 merged first in order to get CI/CD green.