### PR TITLE
Make the links column in the results table sortable

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,9 +3,9 @@ Release Notes
 
 **2.1.2 (unreleased)**
 
-* Make the ``Results`` table ``Links`` column sortable (`#242 https://github.com/pytest-dev/pytest-html/issues/242>`_)
+* Make the ``Results`` table ``Links`` column sortable (`#242 <https://github.com/pytest-dev/pytest-html/issues/242>`_)
 
-  * Thanks to `@vashirov <https://github.com/vashirov>_` for reporting and `@gnikonorov <https://github.com/gnikonorov>_` for the fix
+  * Thanks to `@vashirov <https://github.com/vashirov>`_ for reporting and `@gnikonorov <https://github.com/gnikonorov>`_ for the fix
 
 * Fix issue with missing image or video in extras. (`#265 <https://github.com/pytest-dev/pytest-html/issues/265>`_ and `pytest-selenium#237 <https://github.com/pytest-dev/pytest-selenium/issues/237>`_)
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,10 @@ Release Notes
 
 **2.1.2 (unreleased)**
 
+* Make the ``Results`` table ``Links`` column sortable (`#242 https://github.com/pytest-dev/pytest-html/issues/242>`_)
+
+  * Thanks to `@vashirov <https://github.com/vashirov>_` for reporting and `@gnikonorov <https://github.com/gnikonorov>_` for the fix
+
 * Fix issue with missing image or video in extras. (`#265 <https://github.com/pytest-dev/pytest-html/issues/265>`_ and `pytest-selenium#237 <https://github.com/pytest-dev/pytest-selenium/issues/237>`_)
 
   * Thanks to `@p00j4 <https://github.com/p00j4>`_ and `@anothermattbrown <https://github.com/anothermattbrown>`_ for reporting and `@christiansandberg <https://github.com/christiansandberg>`_ and `@superdodd <https://github.com/superdodd>`_ and `@dhalperi <https://github.com/dhalperi>`_ for the fix

--- a/pytest_html/plugin.py
+++ b/pytest_html/plugin.py
@@ -498,7 +498,7 @@ class HTMLReport:
             html.th("Result", class_="sortable result initial-sort", col="result"),
             html.th("Test", class_="sortable", col="name"),
             html.th("Duration", class_="sortable numeric", col="duration"),
-            html.th("Links"),
+            html.th("Links", class_="sortable links", col="links"),
         ]
         session.config.hook.pytest_html_results_table_header(cells=cells)
 

--- a/pytest_html/resources/main.js
+++ b/pytest_html/resources/main.js
@@ -32,6 +32,8 @@ function sort_column(elem) {
         key = key_num;
     } else if (elem.classList.contains('result')) {
         key = key_result;
+    } else if (elem.classList.contains('links')) {
+        key = key_link;
     } else {
         key = key_alpha;
     }
@@ -175,6 +177,13 @@ function key_alpha(col_index) {
 function key_num(col_index) {
     return function(elem) {
         return parseFloat(elem.childNodes[1].childNodes[col_index].firstChild.data);
+    };
+}
+
+function key_link(col_index) {
+    return function(elem) {
+        dataCell = elem.childNodes[1].childNodes[col_index].firstChild
+        return dataCell == null ? "" : dataCell.innerText.toLowerCase();
     };
 }
 

--- a/testing/js_test_report.html
+++ b/testing/js_test_report.html
@@ -20,7 +20,7 @@
           <th class="sortable result initial-sort" col="result">Result</th>
           <th class="sortable" col="name">Test</th>
           <th class="sortable numeric" col="duration">Duration</th>
-          <th class="sortable" col=links">Links</th></tr>
+          <th class="sortable links" col="links">Links</th></tr>
         <tr hidden="true" id="not-found-message">
           <th colspan="5">No results found. Try to check the filters</th>
         </tr>
@@ -30,7 +30,7 @@
           <td class="col-result">Rerun</td>
           <td class="test-1 col-name">rerun.py::test_rexample_1</td>
           <td class="col-duration">1.00</td>
-          <td class="col-links"></td></tr>
+          <td class="col-links"><a class="url" href="http://www.google.com/" target="_blank">URL</a> </td></tr>
         <tr>
           <td class="extra" colspan="5">
             <div class="log">@pytest.mark.flaky(reruns=5)<br/>    def test_example():<br/>        import random<br/>&gt;       assert random.choice([True, False])<br/><span class="error">E       assert False</span><br/><span class="error">E        +  where False = &lt;bound method Random.choice of &lt;random.Random object at 0x7fe80b85f420&gt;&gt;([True, False])</span><br/><span class="error">E        +    where &lt;bound method Random.choice of &lt;random.Random object at 0x7fe80b85f420&gt;&gt; = &lt;module 'random' from '/usr/local/Cellar/python/2.7.12/Frameworks/Python.framework/Versions/2.7/lib/python2.7/random.pyc'&gt;.choice</span><br/><br/>rerun.py:6: AssertionError<br/></div></td></tr></tbody>

--- a/testing/js_test_report.html
+++ b/testing/js_test_report.html
@@ -20,7 +20,7 @@
           <th class="sortable result initial-sort" col="result">Result</th>
           <th class="sortable" col="name">Test</th>
           <th class="sortable numeric" col="duration">Duration</th>
-          <th>Links</th></tr>
+          <th class="sortable" col=links">Links</th></tr>
         <tr hidden="true" id="not-found-message">
           <th colspan="5">No results found. Try to check the filters</th>
         </tr>

--- a/testing/test.js
+++ b/testing/test.js
@@ -48,6 +48,12 @@
                     'rerun results-table-row', 'passed results-table-row');
    sort_column_test('[col=duration]',
                     'passed results-table-row', 'rerun results-table-row');
+
+   //links
+   sort_column_test('[col=links]',
+                    'rerun results-table-row', 'passed results-table-row');
+   sort_column_test('[col=links]',
+                    'passed results-table-row', 'rerun results-table-row');
  });
 
 QUnit.test('filter_table', function(assert){
@@ -123,6 +129,6 @@ QUnit.test('find', function (assert) {
 });
 
 QUnit.test('find_all', function(assert) {
-  assert.equal(find_all('.sortable').length, 3);
+  assert.equal(find_all('.sortable').length, 4);
   assert.equal(find_all('.not-in-table').length, 0);
 });


### PR DESCRIPTION
As per the title, make the `Links` column of the `Results` table sortable

Closes https://github.com/pytest-dev/pytest-html/issues/242