### PR TITLE
Consolidate tox environments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,10 +28,6 @@ jobs:
       env: TOXENV=py36
 
     -
-      python: 3.6
-      env: TOXENV=py36-ansi2html
-
-    -
       python: 3.7
       dist: xenial
       sudo: required
@@ -41,28 +37,14 @@ jobs:
       python: 3.8
       env: TOXENV=py38
 
-    -
-      python: 3.7
-      dist: xenial
-      sudo: required
-      env: TOXENV=py37-ansi2html
-
     - name: devel
       python: 3.8
       dist: xenial
       env: TOXENV=devel
 
     -
-      python: 3.8
-      env: TOXENV=py38-ansi2html
-
-    -
       python: pypy3
       env: TOXENV=pypy3
-
-    -
-      python: pypy3
-      env: TOXENV=pypy3-ansi2html
 
     - stage: deploy
       python: 3.7

--- a/testing/test_pytest_html.py
+++ b/testing/test_pytest_html.py
@@ -809,14 +809,14 @@ class TestHTML:
         assert result.ret == 0
         assert_results(html, passed=1)
 
-    def test_ansi_color(self, testdir):
-        try:
-            import ansi2html  # NOQA
+    @pytest.mark.parametrize(
+        "with_ansi", [True, False],
+    )
+    def test_ansi_color(self, testdir, mocker, with_ansi):
+        if not with_ansi:
+            mock_ansi_support = mocker.patch("pytest_html.plugin.ansi_support")
+            mock_ansi_support.return_value = None
 
-            ANSI = True
-        except ImportError:
-            # ansi2html is not installed
-            ANSI = False
         pass_content = [
             '<span class="ansi31">RCOLOR',
             '<span class="ansi32">GCOLOR',
@@ -834,7 +834,7 @@ class TestHTML:
         result, html = run(testdir, "report.html", "--self-contained-html")
         assert result.ret == 0
         for content in pass_content:
-            if ANSI:
+            if with_ansi:
                 assert content in html
             else:
                 assert content not in html

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
-# Tox (http://tox.testrun.org/) is a tool for running tests
+# Tox (https://tox.readthedocs.io) is a tool for running tests
 # in multiple virtualenvs. This configuration file will run the
 # test suite on all supported python versions. To use it, "pip install tox"
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py{36,37,38,py3}{,-ansi2html}, linting
+envlist = py{36,37,38,py3}, linting
 
 [testenv]
 setenv = PYTHONDONTWRITEBYTECODE=1
@@ -12,7 +12,7 @@ deps =
     pytest-xdist
     pytest-rerunfailures
     pytest-mock
-    py{36,37,38,py3}-ansi2html: ansi2html
+    ansi2html  # soft-dependency
 commands = pytest -v -r a --color=yes --html={envlogdir}/report.html --self-contained-html {posargs}
 
 [testenv:linting]


### PR DESCRIPTION
Simplifies testing matrix by mocking the absence of ansi2html support.

Fixes: #327