### PR TITLE
Sync .pre-commit-config.yaml with pytest

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,6 @@
-# NOTE: We should still add setup-cfg-fmt and mypy, but they require extra work to implement
 repos:
 -   repo: https://github.com/psf/black
-    rev: stable
+    rev: 19.10b0
     hooks:
     -   id: black
         args: [--safe, --quiet]
@@ -26,7 +25,8 @@ repos:
     hooks:
     -   id: flake8
         language_version: python3
-        additional_dependencies: [flake8-typing-imports==1.9.0]
+        additional_dependencies:
+          - flake8-typing-imports==1.9.0
 -   repo: https://github.com/asottile/reorder_python_imports
     rev: v2.3.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,15 +1,69 @@
+# NOTE: We should still add setup-cfg-fmt and mypy, but they require extra work to implement
 repos:
-
 -   repo: https://github.com/psf/black
     rev: stable
     hooks:
     -   id: black
         args: [--safe, --quiet]
+-   repo: https://github.com/asottile/blacken-docs
+    rev: v1.7.0
+    hooks:
+    -   id: blacken-docs
+        additional_dependencies: [black==19.10b0]
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.1.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: fix-encoding-pragma
+        args: [--remove]
+    -   id: check-yaml
+    -   id: debug-statements
+        exclude: _pytest/(debugging|hookspec).py
         language_version: python3
-
 -   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.7
+    rev: 3.8.2
     hooks:
     -   id: flake8
-        exclude: docs
         language_version: python3
+        additional_dependencies: [flake8-typing-imports==1.9.0]
+-   repo: https://github.com/asottile/reorder_python_imports
+    rev: v2.3.0
+    hooks:
+    -   id: reorder-python-imports
+        args: ['--application-directories=.:src', --py3-plus]
+-   repo: https://github.com/asottile/pyupgrade
+    rev: v2.4.4
+    hooks:
+    -   id: pyupgrade
+        args: [--py3-plus]
+-   repo: local
+    hooks:
+    -   id: rst
+        name: rst
+        entry: rst-lint --encoding utf-8
+        files: ^(RELEASING.rst|README.rst|TIDELIFT.rst)$
+        language: python
+        additional_dependencies: [pygments, restructuredtext_lint]
+    -   id: changelogs-rst
+        name: changelog filenames
+        language: fail
+        entry: 'changelog files must be named ####.(breaking|bugfix|deprecation|doc|feature|improvement|trivial|vendor).rst'
+        exclude: changelog/(\d+\.(breaking|bugfix|deprecation|doc|feature|improvement|trivial|vendor).rst|README.rst|_template.rst)
+        files: ^changelog/
+    -   id: py-deprecated
+        name: py library is deprecated
+        language: pygrep
+        entry: >
+            (?x)\bpy\.(
+                _code\.|
+                builtin\.|
+                code\.|
+                io\.|
+                path\.local\.sysfind|
+                process\.|
+                std\.|
+                error\.|
+                xml\.
+            )
+        types: [python]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,6 @@ repos:
         args: [--remove]
     -   id: check-yaml
     -   id: debug-statements
-        exclude: _pytest/(debugging|hookspec).py
         language_version: python3
 -   repo: https://gitlab.com/pycqa/flake8
     rev: 3.8.2
@@ -31,7 +30,7 @@ repos:
     rev: v2.3.0
     hooks:
     -   id: reorder-python-imports
-        args: ['--application-directories=.:src', --py3-plus]
+        args: ['--application-directories=.:pytest_html:testing', --py3-plus]
 -   repo: https://github.com/asottile/pyupgrade
     rev: v2.4.4
     hooks:
@@ -42,28 +41,6 @@ repos:
     -   id: rst
         name: rst
         entry: rst-lint --encoding utf-8
-        files: ^(RELEASING.rst|README.rst|TIDELIFT.rst)$
+        files: ^(CHANGES.rst|development.rst|README.rst)$
         language: python
         additional_dependencies: [pygments, restructuredtext_lint]
-    -   id: changelogs-rst
-        name: changelog filenames
-        language: fail
-        entry: 'changelog files must be named ####.(breaking|bugfix|deprecation|doc|feature|improvement|trivial|vendor).rst'
-        exclude: changelog/(\d+\.(breaking|bugfix|deprecation|doc|feature|improvement|trivial|vendor).rst|README.rst|_template.rst)
-        files: ^changelog/
-    -   id: py-deprecated
-        name: py library is deprecated
-        language: pygrep
-        entry: >
-            (?x)\bpy\.(
-                _code\.|
-                builtin\.|
-                code\.|
-                io\.|
-                path\.local\.sysfind|
-                process\.|
-                std\.|
-                error\.|
-                xml\.
-            )
-        types: [python]

--- a/README.rst
+++ b/README.rst
@@ -97,8 +97,9 @@ By default report title will be the filename of the report, you can edit it by u
    import pytest
    from py.xml import html
 
-   def pytest_html_report_title(report)
-      report.title = "My very own title!"
+
+   def pytest_html_report_title(report):
+       report.title = "My very own title!"
 
 Environment
 ~~~~~~~~~~~
@@ -110,7 +111,7 @@ via the :code:`pytest_configure` hook:
 .. code-block:: python
 
   def pytest_configure(config):
-      config._metadata['foo'] = 'bar'
+      config._metadata["foo"] = "bar"
 
 The generated table will be sorted alphabetically unless the metadata is a
 :code:`collections.OrderedDict`.
@@ -124,6 +125,7 @@ You can edit the *Summary* section by using the :code:`pytest_html_results_summa
 
    import pytest
    from py.xml import html
+
 
    def pytest_html_results_summary(prefix, summary, postfix):
        prefix.extend([html.p("foo: bar")])
@@ -170,19 +172,21 @@ conftest.py file:
 .. code-block:: python
 
   import pytest
+
+
   @pytest.hookimpl(hookwrapper=True)
   def pytest_runtest_makereport(item, call):
-      pytest_html = item.config.pluginmanager.getplugin('html')
+      pytest_html = item.config.pluginmanager.getplugin("html")
       outcome = yield
       report = outcome.get_result()
-      extra = getattr(report, 'extra', [])
-      if report.when == 'call':
+      extra = getattr(report, "extra", [])
+      if report.when == "call":
           # always add url to report
-          extra.append(pytest_html.extras.url('http://www.example.com/'))
-          xfail = hasattr(report, 'wasxfail')
+          extra.append(pytest_html.extras.url("http://www.example.com/"))
+          xfail = hasattr(report, "wasxfail")
           if (report.skipped and xfail) or (report.failed and not xfail):
               # only add additional html on failure
-              extra.append(pytest_html.extras.html('<div>Additional HTML</div>'))
+              extra.append(pytest_html.extras.html("<div>Additional HTML</div>"))
           report.extra = extra
 
 You can also specify the :code:`name` argument for all types other than :code:`html` which will change the title of the
@@ -190,7 +194,7 @@ created hyper link:
 
 .. code-block:: python
 
-    extra.append(pytest_html.extras.text('some string', name='Different title'))
+    extra.append(pytest_html.extras.text("some string", name="Different title"))
 
 It is also possible to use the fixture :code:`extra` to add content directly
 in a test function without implementing hooks. These will generally end up
@@ -200,8 +204,9 @@ before any extras added by plugins.
 
    from pytest_html import extras
 
+
    def test_extra(extra):
-      extra.append(extras.text('some string'))
+       extra.append(extras.text("some string"))
 
 
 Modifying the results table
@@ -218,15 +223,18 @@ column:
   from py.xml import html
   import pytest
 
+
   def pytest_html_results_table_header(cells):
-      cells.insert(2, html.th('Description'))
-      cells.insert(1, html.th('Time', class_='sortable time', col='time'))
+      cells.insert(2, html.th("Description"))
+      cells.insert(1, html.th("Time", class_="sortable time", col="time"))
       cells.pop()
+
 
   def pytest_html_results_table_row(report, cells):
       cells.insert(2, html.td(report.description))
-      cells.insert(1, html.td(datetime.utcnow(), class_='col-time'))
+      cells.insert(1, html.td(datetime.utcnow(), class_="col-time"))
       cells.pop()
+
 
   @pytest.hookimpl(hookwrapper=True)
   def pytest_runtest_makereport(item, call):
@@ -242,9 +250,10 @@ following example removes all passed results from the report:
 
   import pytest
 
+
   def pytest_html_results_table_row(report, cells):
       if report.passed:
-        del cells[:]
+          del cells[:]
 
 The log output and additional HTML can be modified by implementing the
 :code:`pytest_html_results_html` hook. The following example replaces all
@@ -254,10 +263,11 @@ additional HTML and log output with a notice that the log is empty:
 
   import pytest
 
+
   def pytest_html_results_table_html(report, data):
       if report.passed:
           del data[:]
-          data.append(html.div('No log output captured.', class_='empty log'))
+          data.append(html.div("No log output captured.", class_="empty log"))
 
 Display options
 ---------------

--- a/pytest_html/__init__.py
+++ b/pytest_html/__init__.py
@@ -1,4 +1,5 @@
-from pkg_resources import get_distribution, DistributionNotFound
+from pkg_resources import DistributionNotFound
+from pkg_resources import get_distribution
 
 
 try:

--- a/pytest_html/plugin.py
+++ b/pytest_html/plugin.py
@@ -1,30 +1,30 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-from base64 import b64encode, b64decode
-from collections import OrderedDict
-from functools import lru_cache
-import importlib
-from os.path import isfile
+import bisect
 import datetime
+import importlib
 import json
 import os
-import pkg_resources
-import time
-import bisect
-import warnings
 import re
-
+import time
+import warnings
+from base64 import b64decode
+from base64 import b64encode
+from collections import OrderedDict
+from functools import lru_cache
 from html import escape
+from os.path import isfile
+
+import pkg_resources
 import pytest
-
-from py.xml import html, raw
-
-from . import extras
-from . import __version__, __pypi_url__
-
 from _pytest.logging import _remove_ansi_escape_sequences
+from py.xml import html
+from py.xml import raw
+
+from . import __pypi_url__
+from . import __version__
+from . import extras
 
 
 @lru_cache()
@@ -88,7 +88,7 @@ def pytest_configure(config):
     if htmlpath:
         for csspath in config.getoption("css"):
             if not os.path.exists(csspath):
-                raise IOError(f"No such file or directory: '{csspath}'")
+                raise OSError(f"No such file or directory: '{csspath}'")
         if not hasattr(config, "workerinput"):
             # prevent opening htmlpath on worker nodes (xdist)
             config._html = HTMLReport(htmlpath, config)
@@ -119,8 +119,10 @@ def extra(pytestconfig):
     .. code-block:: python
 
         import pytest_html
+
+
         def test_foo(extra):
-            extra.append(pytest_html.extras.url('http://www.example.com/'))
+            extra.append(pytest_html.extras.url("http://www.example.com/"))
     """
     pytestconfig.extras = []
     yield pytestconfig.extras
@@ -434,7 +436,7 @@ class HTMLReport:
             self.style_css += "\n * CUSTOM CSS"
             self.style_css += f"\n * {path}"
             self.style_css += "\n ******************************/\n\n"
-            with open(path, "r") as f:
+            with open(path) as f:
                 self.style_css += f.read()
 
         css_href = "assets/style.css"

--- a/testing/test_pytest_html.py
+++ b/testing/test_pytest_html.py
@@ -1,14 +1,13 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-from base64 import b64encode
 import json
 import os
-import pkg_resources
 import random
 import re
+from base64 import b64encode
 
+import pkg_resources
 import pytest
 
 pytest_plugins = ("pytester",)


### PR DESCRIPTION
Sync the ` .pre-commit-config.yaml` file with `pytest`'s as much as possible for a better developer experience.

The following diffs that cause `pre-commit` behavior differences between the two `pre-commit` workflows still exist:
```
gnikonorov:~/pytest-html$ diff .pre-commit-config.yaml ../pytest/.pre-commit-config.yaml
...
>           - flake8-docstrings==1.5.0
...
> -   repo: https://github.com/asottile/setup-cfg-fmt
>      ...
> -   repo: https://github.com/pre-commit/mirrors-mypy
        ...
46a61,82
>     -   id: changelogs-rst
>          ....
>     -   id: py-deprecated
>         ...
gnikonorov:~/pytest-html$
```

This is why:
- `flake8-docstrings`: requires a big documentation push, so I deferred
- `setup-cfg-fmt`: requires changes to `setup.cfg` which I believe should tackled separately
- `mirrors-mypy`: requires typing. I would like to add this, but I think it is beyond the scope of this PR
- `changelogs-rst`: ends up skipping the changelog is not compatible with this repos changelog format
- `py-deprecated`: is not applicable to this project

@BeyondEvil @ssbarnea if neither of you object, I'll raise an issue to add typing/mypy + any of the other above targets we think are useful