### PR TITLE
Enable/fix Windows testing, enable Mac/Windows in Github Actions: Closes #336

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -15,21 +15,65 @@ on:
 jobs:
   build:
     name: ${{ matrix.name }}
-    runs-on: ubuntu-18.04
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         include:
-          - name: linting
+          - os: ubuntu-18.04
+            name: linting-ubuntu
             python-version: 3.6
-          - name: py36
+
+          - os: ubuntu-18.04
+            name: py36-ubuntu
             python-version: 3.6
-          - name: py37
+
+          - os: windows-latest
+            name: py36-windows
+            python-version: 3.6
+
+          - os: macOS-latest
+            name: py36-mac
+            python-version: 3.6
+
+          - os: ubuntu-18.04
+            name: py37-ubuntu
             python-version: 3.7
-          - name: py38
+
+          - os: windows-latest
+            name: py37-windows
+            python-version: 3.7
+
+          - os: macOS-latest
+            name: py37-mac
+            python-version: 3.7
+
+          - os: ubuntu-18.04
+            name: py38-ubuntu
             python-version: 3.8
-          - name: pypy3
+
+          - os: windows-latest
+            name: py38-windows
+            python-version: 3.8
+
+          - os: macOS-latest
+            name: py38-mac
+            python-version: 3.8
+
+          - os: ubuntu-18.04
+            name: pypy3-ubuntu
+            python-version: pypy3
+
+          - os: windows-latest
+            name: pypy3-windows
+            python-version: pypy3
+
+          - os: macOS-latest
+            name: pypy3-mac
             python-version: pypy3
     steps:
+    - name: Set Newline Behavior
+      run : |
+        git config --global core.autocrlf false
     - uses: actions/checkout@master
     - name: Set up Python
       uses: actions/setup-python@v2
@@ -38,6 +82,12 @@ jobs:
     - name: Install tox
       run: |
         python -m pip install --upgrade tox
+    - name: Get Tox Environment Name From Matrix Name
+      uses: rishabhgupta/split-by@v1
+      id: split
+      with:
+        string: '${{ matrix.name }}'
+        split-by: '-'
     - name: Test with tox
       run: |
-        python -m tox -e ${{ matrix.name }}
+        python -m tox -e ${{ steps.split.outputs._0}}

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -4,9 +4,10 @@ on:
   create:  # is used for publishing to PyPI and TestPyPI
     tags:  # any tag regardless of its name, no branches
   push:  # only publishes pushes to the main branch to TestPyPI
-    branches:  # any branch but not tag
-    - >-
-      **
+    branches:  # any maintenance branch but not tag
+      # avoid generic ** as it duplicates builds from temporary branches
+      - "master"
+      - "stable/**"
     tags-ignore:
     - >-
       **
@@ -70,6 +71,22 @@ jobs:
           - os: macOS-latest
             name: pypy3-mac
             python-version: pypy3
+
+          - os: ubuntu-18.04
+            name: py39-ubuntu
+            python-version: 3.9
+
+          - os: windows-latest
+            name: py39-windows
+            python-version: 3.9
+
+          - os: macOS-latest
+            name: py39-mac
+            python-version: 3.9
+
+          - os: ubuntu-18.04
+            name: devel-ubuntu
+            python-version: 3.8
     steps:
     - name: Set Newline Behavior
       run : |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,8 +24,7 @@ repos:
     hooks:
     -   id: flake8
         language_version: python3
-        additional_dependencies:
-          - flake8-typing-imports==1.9.0
+        additional_dependencies: [flake8-typing-imports==1.9.0, flake8-builtins==1.5.3]
 -   repo: https://github.com/asottile/reorder_python_imports
     rev: v2.3.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,9 @@ repos:
     hooks:
     -   id: flake8
         language_version: python3
-        additional_dependencies: [flake8-typing-imports==1.9.0, flake8-builtins==1.5.3]
+        additional_dependencies:
+        - flake8-builtins==1.5.3
+        - flake8-typing-imports==1.9.0
 -   repo: https://github.com/asottile/reorder_python_imports
     rev: v2.3.0
     hooks:

--- a/pytest_html/extras.py
+++ b/pytest_html/extras.py
@@ -10,10 +10,10 @@ FORMAT_URL = "url"
 FORMAT_VIDEO = "video"
 
 
-def extra(content, format, name=None, mime_type=None, extension=None):
+def extra(content, format_type, name=None, mime_type=None, extension=None):
     return {
         "name": name,
-        "format": format,
+        "format_type": format_type,
         "content": content,
         "mime_type": mime_type,
         "extension": extension,

--- a/pytest_html/plugin.py
+++ b/pytest_html/plugin.py
@@ -235,13 +235,13 @@ class HTMLReport:
 
         def append_extra_html(self, extra, extra_index, test_index):
             href = None
-            if extra.get("format") == extras.FORMAT_IMAGE:
+            if extra.get("format_type") == extras.FORMAT_IMAGE:
                 self._append_image(extra, extra_index, test_index)
 
-            elif extra.get("format") == extras.FORMAT_HTML:
+            elif extra.get("format_type") == extras.FORMAT_HTML:
                 self.additional_html.append(html.div(raw(extra.get("content"))))
 
-            elif extra.get("format") == extras.FORMAT_JSON:
+            elif extra.get("format_type") == extras.FORMAT_JSON:
                 content = json.dumps(extra.get("content"))
                 if self.self_contained:
                     href = data_uri(content, mime_type=extra.get("mime_type"))
@@ -250,7 +250,7 @@ class HTMLReport:
                         content, extra_index, test_index, extra.get("extension")
                     )
 
-            elif extra.get("format") == extras.FORMAT_TEXT:
+            elif extra.get("format_type") == extras.FORMAT_TEXT:
                 content = extra.get("content")
                 if isinstance(content, bytes):
                     content = content.decode("utf-8")
@@ -261,17 +261,17 @@ class HTMLReport:
                         content, extra_index, test_index, extra.get("extension")
                     )
 
-            elif extra.get("format") == extras.FORMAT_URL:
+            elif extra.get("format_type") == extras.FORMAT_URL:
                 href = extra.get("content")
 
-            elif extra.get("format") == extras.FORMAT_VIDEO:
+            elif extra.get("format_type") == extras.FORMAT_VIDEO:
                 self._append_video(extra, extra_index, test_index)
 
             if href is not None:
                 self.links_html.append(
                     html.a(
                         extra.get("name"),
-                        class_=extra.get("format"),
+                        class_=extra.get("format_type"),
                         href=href,
                         target="_blank",
                     )

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [bdist_wheel]
-universal = 1
+universal = 0

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3 :: Only",
     ],
 )

--- a/testing/test_pytest_html.py
+++ b/testing/test_pytest_html.py
@@ -1,6 +1,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+import builtins
 import json
 import os
 import random
@@ -11,6 +12,21 @@ import pkg_resources
 import pytest
 
 pytest_plugins = ("pytester",)
+
+# Force a utf-8 encoding on file io. See
+# https://github.com/pytest-dev/pytest-html/issues/336
+#  If we drop support for Python 3.6 and earlier could use python -X utf8 instead.
+_real_open = builtins.open
+
+
+def _open(file, mode="r", buffering=-1, encoding=None, *args, **kwargs):
+    if mode in ("r", "w") and encoding is None:
+        encoding = "utf-8"
+
+    return _real_open(file, mode, buffering, encoding, *args, **kwargs)
+
+
+builtins.open = _open
 
 
 def remove_deprecation_from_recwarn(recwarn):

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py{36,37,38,py3}, linting
+envlist = py{36,37,38,39,py3}, linting
 
 [testenv]
 setenv = PYTHONDONTWRITEBYTECODE=1

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,11 @@ basepython = python3
 pip_pre = True
 deps =
     {[testenv]deps}
-    pytest @ git+https://github.com/pytest-dev/pytest.git
+    ansi2html @ git+https://github.com/pycontribs/ansi2html.git
+    pytest-rerunfailures @ git+https://github.com/pytest-dev/pytest-rerunfailures.git
+    # Temporary disable pytest git install due to
+    # https://github.com/pytest-dev/pytest-rerunfailures/issues/134
+    # pytest @ git+https://github.com/pytest-dev/pytest.git
 
 [flake8]
 max-line-length = 88


### PR DESCRIPTION
Fix the default encoding by patching open to always use utf-8. This is the default on *nix based systems, though is different on Windows (and possibly others). 

Also while here, add testing for Mac/Windows to Github Actions