### PR TITLE
Enable devel pipeline

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -27,6 +27,8 @@ jobs:
             python-version: 3.7
           - name: py38
             python-version: 3.8
+          - name: devel
+            python-version: 3.8
           - name: pypy3
             python-version: pypy3
     steps:

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,11 @@ basepython = python3
 pip_pre = True
 deps =
     {[testenv]deps}
-    pytest @ git+https://github.com/pytest-dev/pytest.git
+    ansi2html @ git+https://github.com/pycontribs/ansi2html.git
+    pytest-rerunfailures @ git+https://github.com/pytest-dev/pytest-rerunfailures.git
+    # Temporary disable pytest git install due to
+    # https://github.com/pytest-dev/pytest-rerunfailures/issues/134
+    # pytest @ git+https://github.com/pytest-dev/pytest.git
 
 [flake8]
 max-line-length = 88


### PR DESCRIPTION
This addressed silent regression that was caused by pytest 6.1.x removal of private member which was used by rerunfailures plugin. This broke our `tox -e devel` job and because we did not run it on CI, it took 3 months discover the issue.

- runs devel testing on CI
- install ansi2html and pytest-rerunfailures from git in devel job
- temporary disable pytest install from git due to known bug. I will personally revert this part as soon the issue is fixed upstream.

Related: https://github.com/pytest-dev/pytest-rerunfailures/issues/134