### PR TITLE
Add support for py39

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -27,6 +27,8 @@ jobs:
             python-version: 3.7
           - name: py38
             python-version: 3.8
+          - name: py39
+            python-version: 3.9
           - name: pypy3
             python-version: pypy3
     steps:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [bdist_wheel]
-universal = 1
+universal = 0

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3 :: Only",
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py{36,37,38,py3}, linting
+envlist = py{36,37,38,39,py3}, linting
 
 [testenv]
 setenv = PYTHONDONTWRITEBYTECODE=1


### PR DESCRIPTION
- enable tox py39 env
- expose py39 support in project metadata
- enable py39 github workflow
- corrects mistake on universal wheel (no py2 support)