### PR TITLE
Avoid duplicate builds on github

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -4,9 +4,10 @@ on:
   create:  # is used for publishing to PyPI and TestPyPI
     tags:  # any tag regardless of its name, no branches
   push:  # only publishes pushes to the main branch to TestPyPI
-    branches:  # any branch but not tag
-    - >-
-      **
+    branches:  # any maintenance branch but not tag
+      # avoid generic ** as it duplicates builds from temporary branches
+      - "master"
+      - "stable/**"
     tags-ignore:
     - >-
       **


### PR DESCRIPTION
Fixes issue that caused duplicated jobs running for all PRs coming from internal temporary branches. Duplicated jobs are confusing and also cause performance degradation.

A thumb rule is that branches pattern configured for the workflow should match the branch protection pattern from repository settings.