### PR TITLE
Add flake8-builtins plugin to the flake8 precommit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,8 +24,7 @@ repos:
     hooks:
     -   id: flake8
         language_version: python3
-        additional_dependencies:
-          - flake8-typing-imports==1.9.0
+        additional_dependencies: [flake8-typing-imports==1.9.0, flake8-builtins==1.5.3]
 -   repo: https://github.com/asottile/reorder_python_imports
     rev: v2.3.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,9 @@ repos:
     hooks:
     -   id: flake8
         language_version: python3
-        additional_dependencies: [flake8-typing-imports==1.9.0, flake8-builtins==1.5.3]
+        additional_dependencies:
+        - flake8-builtins==1.5.3
+        - flake8-typing-imports==1.9.0
 -   repo: https://github.com/asottile/reorder_python_imports
     rev: v2.3.0
     hooks:


### PR DESCRIPTION
Add [flake8-builtins](https://pypi.org/project/flake8-builtins/) to our workflow so that we prevent committers from accidentally shadowing builtins.

With this plugin, changes like this:
```
diff --git a/pytest_html/plugin.py b/pytest_html/plugin.py
index c35e0b1..ded4553 100644
--- a/pytest_html/plugin.py
+++ b/pytest_html/plugin.py
@@ -693,6 +693,7 @@ class HTMLReport:
             self.append_failed(report)

     def pytest_sessionstart(self, session):
+        format = "this is shadowing a builtin"
         self.suite_start_time = time.time()

     def pytest_sessionfinish(self, session):
```

Would trigger an error like `A001`:
```
flake8...................................................................Failed
- hook id: flake8
- exit code: 1

pytest_html/plugin.py:696:9: A001 variable "format" is shadowing a python builtin
pytest_html/plugin.py:696:9: F841 local variable 'format' is assigned to but never used

Reorder python imports...................................................Passed
```