### PR TITLE
Support tox isolated builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[build-system]
+requires = [
+  "setuptools>=50.3.2",
+]
+build-backend = "setuptools.build_meta"

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@
 
 [tox]
 envlist = py{36,37,38,39,py3}, linting
+isolated_build = True
 
 [testenv]
 setenv = PYTHONDONTWRITEBYTECODE=1


### PR DESCRIPTION
Support [isolated builds](https://tox.readthedocs.io/en/latest/config.html#conf-isolated_build) in `tox`, for a better developer experience