### PR TITLE
Add coverage tox target

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,15 @@
+[paths]
+source =
+    ../pytest_html
+    */site-packages/pytest_html
+
+[run]
+branch = true
+parallel = true
+source =
+    pytest_html
+    .
+
+[report]
+show_missing = true
+precision = 2

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,15 @@ deps =
     ansi2html  # soft-dependency
 commands = pytest -v -r a --color=yes --html={envlogdir}/report.html --self-contained-html {posargs}
 
+[testenv:coverage]
+deps =
+    ansi2html  # soft-dependency
+    pytest-cov
+    pytest-mock
+    pytest-rerunfailures
+    pytest-xdist
+commands = pytest -v -r a --color=yes --html={envlogdir}/report.html --self-contained-html --cov=pytest_html --cov-config={toxinidir}/.coveragerc testing/  {posargs}
+
 [testenv:linting]
 skip_install = True
 basepython = python3


### PR DESCRIPTION
Add a tox target for generating coverage reports. I am doing this so that we can grow our test coverage. When the target is run, we get the following output after the pytest suite finishes:
```
-------------------------------------------------------------------------- generated html file: file:///home/gnikonorov/pytest-html/.tox/coverage/log/report.html --------------------------------------------------------------------------

----------- coverage: platform linux, python 3.6.9-final-0 -----------
Name                      Stmts   Miss Branch BrPart     Cover   Missing
------------------------------------------------------------------------
pytest_html/__init__.py       7      2      0      0    71.43%   7-9
pytest_html/extras.py        28     11      0      0    60.71%   14, 24, 28, 32, 36, 40, 44, 48, 52, 56, 60
pytest_html/hooks.py          5      0      0      0   100.00%
pytest_html/plugin.py       376    300    136      4    16.02%   33-38, 89->exit, 90->91, 91-92, 93->95, 95-96, 101->102, 102-103, 128-130, 134-135, 140-152, 156-196, 202-211, 216-234, 237-279, 282-320, 325-357, 360-364, 367-371, 374-384, 387-393, 396-406, 409-414, 418-419, 422-585, 588-612, 615-628, 631-683, 689, 692-693, 696, 699-701, 704
------------------------------------------------------------------------
TOTAL                       416    313    136      4    19.75%
```

The next steps assuming we're all on board would be:
- Set up codecov for this project
- Publish the results of this run to codecov
- Grow our coverage

I used pytest-cov's [adhoc-layout example](https://github.com/pytest-dev/pytest-cov/tree/master/examples/adhoc-layout) as a starting point