### PR TITLE
Respect pytest --capture=no and -s flags

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,10 @@ Release Notes
 
 **2.1.2 (unreleased)**
 
+* Respect ``--capture=no`` and ``-s`` pytest flags (`#171 <https://github.com/pytest-dev/pytest-html/issues/171>`_)
+
+  * Thanks to `@bigunyak <https://github.com/bigunyak>`_ for reporting and `@gnikonorov <https://github.com/gnikonorov>`_ for the fix
+
 * Make the ``Results`` table ``Links`` column sortable (`#242 <https://github.com/pytest-dev/pytest-html/issues/242>`_)
 
   * Thanks to `@vashirov <https://github.com/vashirov>`_ for reporting and `@gnikonorov <https://github.com/gnikonorov>`_ for the fix

--- a/pytest_html/plugin.py
+++ b/pytest_html/plugin.py
@@ -278,10 +278,10 @@ class HTMLReport:
                 )
                 self.links_html.append(" ")
 
-        def append_log_html(self, report, additional_html, capture_value):
+        def append_log_html(self, report, additional_html, pytest_capture_value):
             log = html.div(class_="log")
 
-            if capture_value != "no":
+            if pytest_capture_value != "no":
                 if report.longrepr:
                     # longreprtext is only filled out on failure by pytest
                     #    otherwise will be None.

--- a/testing/test_pytest_html.py
+++ b/testing/test_pytest_html.py
@@ -1041,7 +1041,7 @@ class TestHTML:
         "capture_flag, should_capture",
         [("-s", False), ("--capture=no", False), ("--capture=sys", True)],
     )
-    def test_logcapturing_respects_capture_no(
+    def test_extra_log_reporting_respects_capture_no(
         self, testdir, capture_flag, should_capture
     ):
         testdir.makepyfile(


### PR DESCRIPTION
Make `pytest-html` respect the `--capture=no` and `-s` pytest flags as requested in https://github.com/pytest-dev/pytest-html/issues/171.

Note that this only partially resolves the issue. We should also respect `--show-capture=no`, but I will add that in a follow up pr to make the changes smaller.