### PR TITLE
Prep version 3.0.0 for release

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Release Notes
 -------------
 
-**2.1.2 (unreleased)**
+**3.0.0 (2020-10-25)**
 
 * Respect ``--capture=no`` and ``-s`` pytest flags (`#171 <https://github.com/pytest-dev/pytest-html/issues/171>`_)
 


### PR DESCRIPTION
Prep version 3.0.0 for release as discussed in https://github.com/pytest-dev/pytest-html/issues/355. Major bump is due to https://github.com/pytest-dev/pytest-html/pull/347

I plan on releasing a new version the same day this PR merges