### PR TITLE
Assure scm versioning is pypa compatible

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,12 @@
 [build-system]
 requires = [
-  "setuptools>=50.3.2",
+  "pip >= 19.3.1",
+  "setuptools >= 42",
+  "setuptools_scm[toml] >= 3.5.0",
+  "setuptools_scm_git_archive >= 1.1",
+  "wheel >= 0.33.6",
 ]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+local_scheme = "no-local-version"

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="pytest-html",
-    use_scm_version=True,
+    use_scm_version={"local_scheme": "no-local-version"},
     description="pytest plugin for generating HTML reports",
     long_description=open("README.rst").read(),
     author="Dave Hunt",


### PR DESCRIPTION
This fixes the issue of releasing test.pypi.org containers that were not tagged by making the versioning compatible with publishing requirements (taken from other places where I am using it, mainly avoids using ``+`` in version and instead produces something like ``2.1.2.dev47`` which is accepted.

Related: https://github.com/pytest-dev/pytest-html/issues/322#issuecomment-721315174