### PR TITLE
Prep version 3.1.0 for release 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Release Notes
 -------------
 
-**3.1.0 (unreleased)**
+**3.1.0 (2020-12-2)**
 
 * Stop attaching test reruns to final test report entries (`#374 <https://github.com/pytest-dev/pytest-html/issues/374>`_)
 


### PR DESCRIPTION
Set the proper date for `v. 3.1.0` due to tomorrow's release. The date picked is the date the release will be published to PyPI.