### PR TITLE
Handle flaky windows test by rerunning

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,6 +9,7 @@ tox = "*"
 flake8 = "==3.8.4" # also bump this in .pre-commit-config.yaml
 black = "==20.8b1" # also bump this in .pre-commit-config.yaml
 pre-commit = "*"
+pytest-rerunfailures = "*"
 
 [packages]
 pytest-html = {editable = true,path = "."}

--- a/testing/test_pytest_html.py
+++ b/testing/test_pytest_html.py
@@ -186,6 +186,7 @@ class TestHTML:
         assert_results(html, passed=0, failed=1)
         assert "AssertionError" in html
 
+    @pytest.mark.flaky(reruns=2)  # test is flaky on windows
     def test_rerun(self, testdir):
         testdir.makeconftest(
             """


### PR DESCRIPTION
Blocked by #416 

I'm thinking about opening a PR with pytest-rerunfailures so that we can provide a condition for the rerun. I only want it to rerun on windows machines.

The styling/indentation changes to .pre-commit-config.yml was made by my yaml linter.

I'm reluctant to set #395 to "fixed" by this PR.