### PR TITLE
Make the report tab title reflect the report name

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Release Notes
 -------------
 
+**3.2.0 (unreleased)**
+
+* Make the report tab title reflect the report name. (`#412 <https://github.com/pytest-dev/pytest-html/issues/412>`_)
+
+  * Thanks to `@gnikonorov <https://github.com/gnikonorov>`_ for the PR
+
 **3.1.1 (2020-12-13)**
 
 * Fix issue with reporting of missing CSS files. (`#388 <https://github.com/pytest-dev/pytest-html/issues/388>`_)

--- a/src/pytest_html/plugin.py
+++ b/src/pytest_html/plugin.py
@@ -510,9 +510,9 @@ class HTMLReport:
         if self.self_contained:
             html_css = html.style(raw(self.style_css))
 
-        head = html.head(
-            html.meta(charset="utf-8"), html.title("Test Report"), html_css
-        )
+        session.config.hook.pytest_html_report_title(report=self)
+
+        head = html.head(html.meta(charset="utf-8"), html.title(self.title), html_css)
 
         class Outcome:
             def __init__(
@@ -610,8 +610,6 @@ class HTMLReport:
             os.path.join(os.path.dirname(__file__), "resources", "main.js")
         ) as main_js_fp:
             main_js = main_js_fp.read()
-
-        session.config.hook.pytest_html_report_title(report=self)
 
         body = html.body(
             html.script(raw(main_js)),

--- a/testing/test_pytest_html.py
+++ b/testing/test_pytest_html.py
@@ -310,7 +310,8 @@ class TestHTML:
     def test_report_title(self, testdir, path, is_custom):
         testdir.makepyfile("def test_pass(): pass")
 
-        custom_report_title = "My Custom Report"
+        report_name = "report.html"
+        report_title = "My Custom Report" if is_custom else report_name
         if is_custom:
             testdir.makeconftest(
                 f"""
@@ -318,27 +319,18 @@ class TestHTML:
                 from py.xml import html
 
                 def pytest_html_report_title(report):
-                    report.title = "{custom_report_title}"
+                    report.title = "{report_title}"
             """
             )
 
-        report_name = "report.html"
         path = os.path.join(path, report_name)
         result, html = run(testdir, path)
         assert result.ret == 0
 
-        report_head_title_string = (
-            f"<title>{custom_report_title}</title>"
-            if is_custom
-            else f"<title>{report_name}</title>"
-        )
+        report_head_title_string = f"<title>{report_title}</title>"
         assert len(re.findall(report_head_title_string, html)) == 1, html
 
-        report_body_title_string = (
-            f"<h1>{custom_report_title}</h1>"
-            if is_custom
-            else f"<h1>{report_name}</h1>"
-        )
+        report_body_title_string = f"<h1>{report_title}</h1>"
         assert len(re.findall(report_body_title_string, html)) == 1, html
 
     def test_report_title_addopts_env_var(self, testdir, monkeypatch):


### PR DESCRIPTION
Make the report tab title the same as the report name in the body for consistency.

Closes https://github.com/pytest-dev/pytest-html/issues/412