### PR TITLE
properly classify all npm dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,9 @@
 {
   "main": "Gruntfile.js",
-  "dependencies": {
+  "devDependencies": {
     "grunt": "^1.3.0",
     "grunt-cli": "^1.3.2",
-    "grunt-contrib-qunit": "^4.0.0"
-  },
-  "devDependencies": {
+    "grunt-contrib-qunit": "^4.0.0",
     "sass": "^1.29.0"
   },
   "scripts": {


### PR DESCRIPTION
Stop classifying dev dependencies as non dev dependencies in the `package.json` file