### PR TITLE
Allow for redacting of environment table values

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,6 +13,10 @@ Version History
 
   * Thanks to `@gnikonorov <https://github.com/gnikonorov>`_ for the PR
 
+* Implement :code:`environment_table_redact_list` to allow for redaction of environment table values. (`#233 <https://github.com/pytest-dev/pytest-html/issues/233>`_)
+
+  * Thanks to `@fenchu <https://github.com/fenchu>`_ for reporting and `@gnikonorov <https://github.com/gnikonorov>`_ for the PR
+
 3.1.1 (2020-12-13)
 ~~~~~~~~~~~~~~~~~~
 

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -82,11 +82,11 @@ and thus not pick up your change.
 
 The generated table will be sorted alphabetically unless the metadata is a :code:`collections.OrderedDict`.
 
-It is also possible to redact variables from the environment table. Redacted variables will have their keys displayed, but their values grayed out.
+It is possible to redact variables from the environment table. Redacted variables will have their names displayed, but their values grayed out.
 This can be achieved by setting :code:`environment_table_redact_list` in your INI configuration file (e.g.: :code:`pytest.ini`).
-:code:`environment_table_redact_list` is a :code:`linelist` of regexes. Any environment table key that matches a regex in this list has its value redacted.
+:code:`environment_table_redact_list` is a :code:`linelist` of regexes. Any environment table variable that matches a regex in this list has its value redacted.
 
-For example, the below will redact all environment table values whose keys match the regexes :code:`^foo$`, :code:`.*redact.*`, or :code:`bar`:
+For example, the following will redact all environment table variables that match the regexes :code:`^foo$`, :code:`.*redact.*`, or :code:`bar`:
 
 .. code-block:: ini
 

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -80,8 +80,20 @@ Note that in the above example `@pytest.hookimpl(tryfirst=True)`_ is important, 
 If this line is omitted, then the *Environment* table will **not** be updated since the :code:`pytest_sessionfinish` of the plugins will execute first,
 and thus not pick up your change.
 
-The generated table will be sorted alphabetically unless the metadata is a
-:code:`collections.OrderedDict`.
+The generated table will be sorted alphabetically unless the metadata is a :code:`collections.OrderedDict`.
+
+It is also possible to redact variables from the environment table. Redacted variables will have their keys displayed, but their values grayed out.
+This can be achieved by setting :code:`environment_table_redact_list` in your INI configuration file (e.g.: :code:`pytest.ini`).
+:code:`environment_table_redact_list` is a :code:`linelist` of regexes. Any environment table key that matches a regex in this list has its value redacted.
+
+For example, the below will redact all environment table values whose keys match the regexes :code:`^foo$`, :code:`.*redact.*`, or :code:`bar`:
+
+.. code-block:: ini
+
+  [pytest]
+  environment_table_redact_list = ^foo$
+      .*redact.*
+      bar
 
 Additional summary information
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/pytest_html/plugin.py
+++ b/src/pytest_html/plugin.py
@@ -53,6 +53,12 @@ def pytest_addoption(parser):
         help="set the maximum filename length for assets "
         "attached to the html report.",
     )
+    parser.addini(
+        "environment_table_redact_list",
+        type="linelist",
+        help="A list of regexes corresponding to environment "
+        "table keys whose values should be redacted from the report",
+    )
 
 
 def pytest_configure(config):

--- a/src/pytest_html/plugin.py
+++ b/src/pytest_html/plugin.py
@@ -57,7 +57,7 @@ def pytest_addoption(parser):
         "environment_table_redact_list",
         type="linelist",
         help="A list of regexes corresponding to environment "
-        "table keys whose values should be redacted from the report",
+        "table variables whose values should be redacted from the report",
     )
 
 

--- a/testing/test_pytest_html.py
+++ b/testing/test_pytest_html.py
@@ -1263,4 +1263,4 @@ class TestHTML:
             variable_value_regex = re.compile(
                 f"<tr>\n.*<td>{variable}</td>\n.*<td>{variable_value}</td></tr>"
             )
-            assert variable_value_regex.search(html) is not None, str(html)
+            assert variable_value_regex.search(html) is not None

--- a/testing/test_pytest_html.py
+++ b/testing/test_pytest_html.py
@@ -1214,7 +1214,7 @@ class TestHTML:
         testdir.makeini(
             """
             [pytest]
-            environment_table_redact_list = foo$
+            environment_table_redact_list = ^foo$
                 .*redact.*
                 bar
         """
@@ -1224,6 +1224,7 @@ class TestHTML:
             """
             def pytest_configure(config):
                 config._metadata["foo"] = "will not appear a"
+                config._metadata["afoo"] = "will appear"
                 config._metadata["foos"] = "will appear"
                 config._metadata["redact"] = "will not appear ab"
                 config._metadata["will_redact"] = "will not appear abc"
@@ -1248,6 +1249,7 @@ class TestHTML:
         black_box_ascii_value = 0x2593
         expected_environment_values = {
             "foo": "".join(chr(black_box_ascii_value) for value in range(17)),
+            "afoo": "will appear",
             "foos": "will appear",
             "redact": "".join(chr(black_box_ascii_value) for value in range(18)),
             "will_redact": "".join(chr(black_box_ascii_value) for value in range(19)),


### PR DESCRIPTION
This PR enables the redaction of environment table values based on the newly added `environment_table_redact_list` INI key.

Please see the following for an example of a redacted environment table entry (`MY_SECRET_KEY`):
![Screen Shot 2020-12-19 at 10 26 04 AM](https://user-images.githubusercontent.com/13026015/102692920-c9dd3b00-41e4-11eb-9de1-60a06d52c1fb.png)

Closes https://github.com/pytest-dev/pytest-html/issues/233