### PR TITLE
Implement the visible URL query parameter to control visibility of test results on page load.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,10 @@ Version History
 3.2.0 (unreleased)
 ~~~~~~~~~~~~~~~~~~
 
+* Implement the ``visible`` URL query parameter to control visiblity of test results on page load. (`#399 <https://github.com/pytest-dev/pytest-html/issues/399>`_)
+
+  * Thanks to `@TheCorp <https://github.com/TheCorp>`_ for reporting and `@gnikonorov <https://github.com/gnikonorov>`_ for the fix
+
 * Make the report tab title reflect the report name. (`#412 <https://github.com/pytest-dev/pytest-html/issues/412>`_)
 
   * Thanks to `@gnikonorov <https://github.com/gnikonorov>`_ for the PR

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,7 +9,7 @@ Version History
 3.2.0 (unreleased)
 ~~~~~~~~~~~~~~~~~~
 
-* Implement the ``visible`` URL query parameter to control visiblity of test results on page load. (`#399 <https://github.com/pytest-dev/pytest-html/issues/399>`_)
+* Implement the ``visible`` URL query parameter to control visibility of test results on page load. (`#399 <https://github.com/pytest-dev/pytest-html/issues/399>`_)
 
   * Thanks to `@TheCorp <https://github.com/TheCorp>`_ for reporting and `@gnikonorov <https://github.com/gnikonorov>`_ for the fix
 

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -234,6 +234,9 @@ additional HTML and log output with a notice that the log is empty:
 Display options
 ---------------
 
+Auto Collapsing Table Rows
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 By default, all rows in the **Results** table will be expanded except those that have :code:`Passed`.
 
 This behavior can be customized either with a query parameter: :code:`?collapsed=Passed,XFailed,Skipped`
@@ -245,6 +248,29 @@ or by setting the :code:`render_collapsed` in a configuration file (pytest.ini, 
   render_collapsed = True
 
 **NOTE:** Setting :code:`render_collapsed` will, unlike the query parameter, affect all statuses.
+
+Controlling Test Result Visability Via Query Params
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+By default, all tests are visible, regardless of their results. It is possible to control which tests are visible on
+page load by passing the :code:`visible` query parameter. To use this parameter, please pass a comma separated list
+of test results you wish to be visible. For exmaple, passing :code:`?visible=passed,skipped` will show only those
+tests in the report that have outcome :code:`passed`, or :code:`skipped`.
+
+Note that this match is case insenstive, so passing :code:`PASSED` and :code:`passed` has the same effect.
+
+The following query parameters may be passed:
+
+* :code:`passed`
+* :code:`skipped`
+* :code:`failed`
+* :code:`error`
+* :code:`xfailed`
+* :code:`xpassed`
+* :code:`rerun`
+
+Formatting the Duration Column
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The formatting of the timestamp used in the :code:`Durations` column can be modified by setting :code:`duration_formatter`
 on the :code:`report` attribute. All `time.strftime`_ formatting directives are supported. In addition, it is possible

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -249,15 +249,15 @@ or by setting the :code:`render_collapsed` in a configuration file (pytest.ini, 
 
 **NOTE:** Setting :code:`render_collapsed` will, unlike the query parameter, affect all statuses.
 
-Controlling Test Result Visability Via Query Params
+Controlling Test Result Visibility Via Query Params
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 By default, all tests are visible, regardless of their results. It is possible to control which tests are visible on
 page load by passing the :code:`visible` query parameter. To use this parameter, please pass a comma separated list
-of test results you wish to be visible. For exmaple, passing :code:`?visible=passed,skipped` will show only those
-tests in the report that have outcome :code:`passed`, or :code:`skipped`.
+of test results you wish to be visible. For example, passing :code:`?visible=passed,skipped` will show only those
+tests in the report that have outcome :code:`passed` or :code:`skipped`.
 
-Note that this match is case insenstive, so passing :code:`PASSED` and :code:`passed` has the same effect.
+Note that this match is case insensitive, so passing :code:`PASSED` and :code:`passed` has the same effect.
 
 The following query parameters may be passed:
 

--- a/src/pytest_html/resources/main.js
+++ b/src/pytest_html/resources/main.js
@@ -63,9 +63,19 @@ function hideExtras(colresultElem) {
 }
 
 function showFilters() {
+    let checked = getQueryParameter('visible') || 'all';
+    checked = checked.toLowerCase();
+
     const filterItems = document.getElementsByClassName('filter');
-    for (let i = 0; i < filterItems.length; i++)
+    for (let i = 0; i < filterItems.length; i++) {
         filterItems[i].hidden = false;
+
+        if (checked != 'all') {
+            filterItems[i].checked = checked.includes(filterItems[i].getAttribute('data-test-result'));
+            filterTable(filterItems[i]);
+        } else
+            filterItems[i].checked = true;
+    }
 }
 
 function addCollapse() {

--- a/src/pytest_html/resources/main.js
+++ b/src/pytest_html/resources/main.js
@@ -74,8 +74,7 @@ function showFilters() {
         if (visibleString != 'all') {
             filterItems[i].checked = checkedItems.includes(filterItems[i].getAttribute('data-test-result'));
             filterTable(filterItems[i]);
-        } else
-            filterItems[i].checked = true;
+        }
     }
 }
 

--- a/src/pytest_html/resources/main.js
+++ b/src/pytest_html/resources/main.js
@@ -63,15 +63,16 @@ function hideExtras(colresultElem) {
 }
 
 function showFilters() {
-    let checked = getQueryParameter('visible') || 'all';
-    checked = checked.toLowerCase();
+    let visibleString = getQueryParameter('visible') || 'all';
+    visibleString = visibleString.toLowerCase();
+    const checkedItems = visibleString.split(',');
 
     const filterItems = document.getElementsByClassName('filter');
     for (let i = 0; i < filterItems.length; i++) {
         filterItems[i].hidden = false;
 
-        if (checked != 'all') {
-            filterItems[i].checked = checked.includes(filterItems[i].getAttribute('data-test-result'));
+        if (visibleString != 'all') {
+            filterItems[i].checked = checkedItems.includes(filterItems[i].getAttribute('data-test-result'));
             filterTable(filterItems[i]);
         } else
             filterItems[i].checked = true;


### PR DESCRIPTION
Implement a new query parameter, `visible`, to control visibility of test results on page load.

Note that `QUnit` makes testing this cumbersome. I tested this locally with all possible combinations and things worked as expected ( as did not passing this argument ). I opened https://github.com/pytest-dev/pytest-html/issues/432 to migrate off QUnit and noted the need for URL parameter tests in the issue.

Closes https://github.com/pytest-dev/pytest-html/issues/399