### PR TITLE
Add a 'keyFloat' function to sort "Duration" column numerically

### DIFF
--- a/src/pytest_html/html_report.py
+++ b/src/pytest_html/html_report.py
@@ -148,7 +148,7 @@ class HTMLReport:
         cells = [
             html.th("Result", class_="sortable result initial-sort", col="result"),
             html.th("Test", class_="sortable", col="name"),
-            html.th("Duration", class_="sortable", col="duration"),
+            html.th("Duration", class_="sortable float", col="duration"),
             html.th("Links", class_="sortable links", col="links"),
         ]
         session.config.hook.pytest_html_results_table_header(cells=cells)

--- a/src/pytest_html/resources/main.js
+++ b/src/pytest_html/resources/main.js
@@ -32,6 +32,8 @@ function sortColumn(elem) {
         key = keyResult;
     } else if (elem.classList.contains('links')) {
         key = keyLink;
+    } else if (elem.classList.contains('float')) {
+        key = keyFloat;
     } else {
         key = keyAlpha;
     }
@@ -178,6 +180,12 @@ function sort(items, keyFunc, reversed) {
 function keyAlpha(colIndex) {
     return function(elem) {
         return elem.childNodes[1].childNodes[colIndex].firstChild.data.toLowerCase();
+    };
+}
+
+function keyFloat(colIndex) {
+    return function(elem) {
+        return Number(elem.childNodes[1].childNodes[colIndex].firstChild.data);
     };
 }
 


### PR DESCRIPTION
... instead of lexicographically. This simple change solves #449 and #413.

**Note** This merge would fix sorting of the *default* contents of the "duration" column. However, this merge would make sorting **not** work if users change formatting following instructions in the User's Guide [Formatting the Duration Column](https://pytest-html.readthedocs.io/en/latest/user_guide.html#formatting-the-duration-column) section. In that case the current lexicographic sorting would be required. Therefore at this point I think the best solution would be to decline this pull request and to change the default formatting of the "duration" column to "%H:%M:%S.%f".