### PR TITLE
Add reusable workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,132 @@
+name: Tests
+
+on:
+  workflow_call:
+
+jobs:
+  test_python:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            name: py36-ubuntu
+            python-version: 3.6
+
+          - os: windows-latest
+            name: py36-windows
+            python-version: 3.6
+
+          - os: macOS-latest
+            name: py36-mac
+            python-version: 3.6
+
+          - os: ubuntu-latest
+            name: py37-ubuntu
+            python-version: 3.7
+
+          - os: windows-latest
+            name: py37-windows
+            python-version: 3.7
+
+          - os: macOS-latest
+            name: py37-mac
+            python-version: 3.7
+
+          - os: ubuntu-latest
+            name: py38-ubuntu
+            python-version: 3.8
+
+          - os: windows-latest
+            name: py38-windows
+            python-version: 3.8
+
+          - os: macOS-latest
+            name: py38-mac
+            python-version: 3.8
+
+          - os: ubuntu-latest
+            name: py39-ubuntu
+            python-version: 3.9
+
+          - os: windows-latest
+            name: py39-windows
+            python-version: 3.9
+
+          - os: macOS-latest
+            name: py39-mac
+            python-version: 3.9
+
+          - os: ubuntu-latest
+            name: pypy3-ubuntu
+            python-version: pypy3
+
+          - os: windows-latest
+            name: pypy3-windows
+            python-version: pypy3
+           # https://github.com/pytest-dev/pytest-html/issues/482
+#          - os: macOS-latest
+#            name: pypy3-mac
+#            python-version: pypy3
+
+          - os: ubuntu-latest
+            name: devel-ubuntu
+            python-version: 3.9
+
+    steps:
+      - name: Set Newline Behavior
+        run : git config --global core.autocrlf false
+      - uses: actions/checkout@master
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix['python-version'] }}
+      - name: Install tox
+        run: python -m pip install --upgrade tox
+      - name: Get Tox Environment Name From Matrix Name
+        uses: rishabhgupta/split-by@v1
+        id: split-matrix-name
+        with:
+          string: '${{ matrix.name }}'
+          split-by: '-'
+      - name: Test with tox
+        run: python -m tox -e ${{ steps.split-matrix-name.outputs._0}}-cov
+       # TODO: https://github.com/pytest-dev/pytest-html/issues/481
+#      - name: Upload coverage to codecov
+#        if: github.event.schedule == ''
+#        uses: codecov/codecov-action@v2
+#        with:
+#          fail_ci_if_error: true
+#          file: ./coverage.xml
+#          flags: tests
+#          name: ${{ matrix.py }} - ${{ matrix.os }}
+#          verbose: true
+
+  test_javascript:
+    name: grunt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+      - name: Install Dependencies
+        run: npm install
+      - name: QUnit Tests
+        run: npm test
+
+  linting:
+    name: linting
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Install tox
+        run: python -m pip install --upgrade tox
+      - name: Lint with tox
+        run: python -m tox -e linting


### PR DESCRIPTION
GitHub Actions recently introduced [reusable workflows](https://github.blog/2021-11-29-github-actions-reusable-workflows-is-generally-available/).

I want to use that functionality to split out the different workflows to make them a little bit more focused and easier to understand.

This is a prepatory step to enable that.