### PR TITLE
Skip coverage for pypy3

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,8 +91,12 @@ jobs:
         with:
           string: '${{ matrix.name }}'
           split-by: '-'
-      - name: Test with tox
+      - name: Test with coverage
+        if: "! contains(matrix.name, 'pypy3')"
         run: python -m tox -e ${{ steps.split-matrix-name.outputs._0}}-cov
+      - name: Test without coverage
+        if: "contains(matrix.name, 'pypy3')"
+        run: python -m tox -e ${{ steps.split-matrix-name.outputs._0}}
        # TODO: https://github.com/pytest-dev/pytest-html/issues/481
 #      - name: Upload coverage to codecov
 #        if: github.event.schedule == ''


### PR DESCRIPTION
Significant decrease as can been seen [here](https://github.com/pytest-dev/pytest-html/actions/runs/1750855366)

Down from almost 40 minutes to less than 10. The outlier now is Windows.