### PR TITLE
Original test cases order kept

### DIFF
--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -261,6 +261,21 @@ or by setting the :code:`render_collapsed` in a configuration file (pytest.ini, 
 
 **NOTE:** Setting :code:`render_collapsed` will, unlike the query parameter, affect all statuses.
 
+
+Keep original test cases run order
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+By default, all rows in the **Results** table will be sorted by category. Failed test cases will be placed at the top of the **Results** table.
+
+This behavior can be customized by setting the :code:`keep_original_order` in a configuration file (pytest.ini, setup.cfg, etc).
+
+.. code-block:: ini
+
+  [pytest]
+  keep_original_order = True
+
+**NOTE:** Setting :code:`keep_original_order` will turn off a possibility of changing order by table headers.
+
 Controlling Test Result Visibility Via Query Params
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/pytest_html/plugin.py
+++ b/src/pytest_html/plugin.py
@@ -59,6 +59,13 @@ def pytest_addoption(parser):
         help="A list of regexes corresponding to environment "
         "table variables whose values should be redacted from the report",
     )
+    parser.addini(
+        "keep_original_order",
+        type="bool",
+        default=False,
+        help="Keep original order of test cases run in report. "
+        "That option turns off a possibility of order rows by table headers.",
+    )
 
 
 def pytest_configure(config):

--- a/testing/test_pytest_html.py
+++ b/testing/test_pytest_html.py
@@ -1095,39 +1095,31 @@ class TestHTML:
         assert len(re.findall(collapsed_html, html)) == expected_count
         assert_results(html, tests=2, passed=1, failed=1)
 
-    @pytest.mark.parametrize("keep_original_order, expected_table_header_tag", [
-        (
+    @pytest.mark.parametrize(
+        "keep_original_order, expected_table_header_tag",
+        [
+            (
                 False,
                 [
-                    {
-                        'html_tag': '<th class=".*sortable.*">',
-                        'expected_count': 4
-                    },
-                    {
-                        'html_tag': '<th class=".*initial-sort.*">',
-                        'expected_count': 1
-                    }
-                ]
-        ),
-        (
+                    {"html_tag": '<th class=".*sortable.*">', "expected_count": 4},
+                    {"html_tag": '<th class=".*initial-sort.*">', "expected_count": 1},
+                ],
+            ),
+            (
                 True,
                 [
-                    {
-                        'html_tag': '<th class=".*sortable.*">',
-                        'expected_count': 0
-                    },
-                    {
-                        'html_tag': '<th class=".*initial-sort.*">',
-                        'expected_count': 0
-                    }
-                ]
-        )
-    ], ids=(
-        "keep_original_order option is not set",
-        "keep_original_order option is set",
-    ))
+                    {"html_tag": '<th class=".*sortable.*">', "expected_count": 0},
+                    {"html_tag": '<th class=".*initial-sort.*">', "expected_count": 0},
+                ],
+            ),
+        ],
+        ids=(
+            "keep_original_order option is not set",
+            "keep_original_order option is set",
+        ),
+    )
     def test_keep_original_order_option_remove_any_sort_class_from_headers(
-            self, testdir, keep_original_order, expected_table_header_tag
+        self, testdir, keep_original_order, expected_table_header_tag
     ):
         testdir.makeini(
             f"""
@@ -1153,36 +1145,41 @@ class TestHTML:
         result, html = run(testdir)
         assert result.ret == 1
         for expect_element in expected_table_header_tag:
-            assert len(
-                re.findall(expect_element["html_tag"], html)
-            ) == expect_element["expected_count"]
+            assert (
+                len(re.findall(expect_element["html_tag"], html))
+                == expect_element["expected_count"]
+            )
         assert_results(html, tests=4, passed=2, failed=2)
 
-    @pytest.mark.parametrize("keep_original_order, expected_order", [
-        (
+    @pytest.mark.parametrize(
+        "keep_original_order, expected_order",
+        [
+            (
                 False,
                 [
                     "test_fail1",
                     "test_fail2",
                     "test_pass1",
                     "test_pass2",
-                ]
-        ),
-        (
+                ],
+            ),
+            (
                 True,
                 [
                     "test_pass1",
                     "test_fail1",
                     "test_pass2",
                     "test_fail2",
-                ]
-        )
-    ], ids=(
-        "keep_original_order option is not set",
-        "keep_original_order option is set",
-    ))
+                ],
+            ),
+        ],
+        ids=(
+            "keep_original_order option is not set",
+            "keep_original_order option is set",
+        ),
+    )
     def test_keep_original_order_option_hold_test_run_order(
-            self, testdir, keep_original_order, expected_order
+        self, testdir, keep_original_order, expected_order
     ):
         testdir.makeini(
             f"""
@@ -1210,7 +1207,7 @@ class TestHTML:
         result_report_test_order = re.findall('<td class="col-name">.*</td>', html)
         assert len(result_report_test_order) == len(expected_order)
         for expected_test_name, result_test_name in zip(
-                expected_order, result_report_test_order
+            expected_order, result_report_test_order
         ):
             assert expected_test_name in result_test_name
         assert_results(html, tests=4, passed=2, failed=2)


### PR DESCRIPTION
Because that sometimes somebody
could want to have a possibility to
keep the original order of test cases
in the report, that possibility was
added. The logic is control by specific
flag in config file.

1. Added necessary option flag in config.
2. Added necessary logic if flag is set to True.
3. Added necessary tests for new logic.
4. Added additional section in documentation
which describes how to turn on the new behaviour.