### PR TITLE
Use pathlib.Path for file path handling

### DIFF
--- a/src/pytest_html/html_report.py
+++ b/src/pytest_html/html_report.py
@@ -87,9 +87,7 @@ class HTMLReport:
         numtests = self.passed + self.failed + self.xpassed + self.xfailed
         generated = datetime.datetime.now()
 
-        with open(
-            os.path.join(os.path.dirname(__file__), "resources", "style.css")
-        ) as style_css_fp:
+        with open(Path(__file__).parent / "resources" / "style.css") as style_css_fp:
             self.style_css = style_css_fp.read()
 
         if ansi_support():
@@ -178,9 +176,7 @@ class HTMLReport:
             ),
         ]
 
-        with open(
-            os.path.join(os.path.dirname(__file__), "resources", "main.js")
-        ) as main_js_fp:
+        with open(Path(__file__).parent / "resources" / "main.js") as main_js_fp:
             main_js = main_js_fp.read()
 
         body = html.body(

--- a/src/pytest_html/html_report.py
+++ b/src/pytest_html/html_report.py
@@ -6,6 +6,7 @@ import re
 import time
 from collections import defaultdict
 from collections import OrderedDict
+from pathlib import Path
 
 from py.xml import html
 from py.xml import raw
@@ -19,10 +20,10 @@ from .util import ansi_support
 
 class HTMLReport:
     def __init__(self, logfile, config):
-        logfile = os.path.expanduser(os.path.expandvars(logfile))
-        self.logfile = os.path.abspath(logfile)
+        logfile = Path(os.path.expandvars(logfile)).expanduser()
+        self.logfile = logfile.absolute()
         self.test_logs = []
-        self.title = os.path.basename(self.logfile)
+        self.title = self.logfile.name
         self.results = []
         self.errors = self.failed = 0
         self.passed = self.skipped = 0
@@ -253,17 +254,17 @@ class HTMLReport:
         return False
 
     def _save_report(self, report_content):
-        dir_name = os.path.dirname(self.logfile)
-        assets_dir = os.path.join(dir_name, "assets")
+        dir_name = self.logfile.parent
+        assets_dir = dir_name / "assets"
 
-        os.makedirs(dir_name, exist_ok=True)
+        dir_name.mkdir(parents=True, exist_ok=True)
         if not self.self_contained:
-            os.makedirs(assets_dir, exist_ok=True)
+            assets_dir.mkdir(parents=True, exist_ok=True)
 
         with open(self.logfile, "w", encoding="utf-8") as f:
             f.write(report_content)
         if not self.self_contained:
-            style_path = os.path.join(assets_dir, "style.css")
+            style_path = assets_dir / "style.css"
             with open(style_path, "w", encoding="utf-8") as f:
                 f.write(self.style_css)
 
@@ -339,4 +340,4 @@ class HTMLReport:
         self._save_report(report_content)
 
     def pytest_terminal_summary(self, terminalreporter):
-        terminalreporter.write_sep("-", f"generated html file: file://{self.logfile}")
+        terminalreporter.write_sep("-", f"generated html file: {self.logfile.as_uri()}")

--- a/src/pytest_html/html_report.py
+++ b/src/pytest_html/html_report.py
@@ -87,8 +87,8 @@ class HTMLReport:
         numtests = self.passed + self.failed + self.xpassed + self.xfailed
         generated = datetime.datetime.now()
 
-        with open(Path(__file__).parent / "resources" / "style.css") as style_css_fp:
-            self.style_css = style_css_fp.read()
+        css_path = Path(__file__).parent / "resources" / "style.css"
+        self.style_css = css_path.read_text()
 
         if ansi_support():
             ansi_css = [
@@ -105,8 +105,7 @@ class HTMLReport:
             self.style_css += "\n * CUSTOM CSS"
             self.style_css += f"\n * {path}"
             self.style_css += "\n ******************************/\n\n"
-            with open(path) as f:
-                self.style_css += f.read()
+            self.style_css += Path(path).read_text()
 
         css_href = "assets/style.css"
         html_css = html.link(href=css_href, rel="stylesheet", type="text/css")
@@ -176,8 +175,8 @@ class HTMLReport:
             ),
         ]
 
-        with open(Path(__file__).parent / "resources" / "main.js") as main_js_fp:
-            main_js = main_js_fp.read()
+        main_js_path = Path(__file__).parent / "resources" / "main.js"
+        main_js = main_js_path.read_text()
 
         body = html.body(
             html.script(raw(main_js)),
@@ -257,12 +256,10 @@ class HTMLReport:
         if not self.self_contained:
             assets_dir.mkdir(parents=True, exist_ok=True)
 
-        with open(self.logfile, "w", encoding="utf-8") as f:
-            f.write(report_content)
+        self.logfile.write_text(report_content)
         if not self.self_contained:
             style_path = assets_dir / "style.css"
-            with open(style_path, "w", encoding="utf-8") as f:
-                f.write(self.style_css)
+            style_path.write_text(self.style_css)
 
     def _post_process_reports(self):
         for test_name, test_reports in self.reports.items():

--- a/src/pytest_html/plugin.py
+++ b/src/pytest_html/plugin.py
@@ -1,7 +1,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-import os
+from pathlib import Path
 
 import pytest
 
@@ -66,7 +66,7 @@ def pytest_configure(config):
     if htmlpath:
         missing_css_files = []
         for csspath in config.getoption("css"):
-            if not os.path.exists(csspath):
+            if not Path(csspath).exists():
                 missing_css_files.append(csspath)
 
         if missing_css_files:

--- a/src/pytest_html/result.py
+++ b/src/pytest_html/result.py
@@ -93,8 +93,9 @@ class TestResult:
         relative_path = f"assets/{asset_file_name}"
 
         kwargs = {"encoding": "utf-8"} if "b" not in mode else {}
-        with open(asset_path, mode, **kwargs) as f:
-            f.write(content)
+        func = asset_path.write_bytes if "b" in mode else asset_path.write_text
+        func(content, **kwargs)
+
         return relative_path
 
     def append_extra_html(self, extra, extra_index, test_index):

--- a/src/pytest_html/result.py
+++ b/src/pytest_html/result.py
@@ -1,5 +1,4 @@
 import json
-import os
 import re
 import time
 import warnings
@@ -7,6 +6,7 @@ from base64 import b64decode
 from base64 import b64encode
 from html import escape
 from os.path import isfile
+from pathlib import Path
 
 from _pytest.logging import _remove_ansi_escape_sequences
 from py.xml import html
@@ -86,11 +86,9 @@ class TestResult:
             str(test_index),
             file_extension,
         )[-self.max_asset_filename_length :]
-        asset_path = os.path.join(
-            os.path.dirname(self.logfile), "assets", asset_file_name
-        )
+        asset_path = Path(self.logfile).parent / "assets" / asset_file_name
 
-        os.makedirs(os.path.dirname(asset_path), exist_ok=True)
+        asset_path.parent.mkdir(exist_ok=True, parents=True)
 
         relative_path = f"assets/{asset_file_name}"
 


### PR DESCRIPTION
This PR changes all file and directory path handling to use `pathlib.Path` instead of using strings and `os.path` functions. The initial reason for this is that simply prepending `"file://"` to the path of the report does not generate a valid URI on Windows, where the directory separator is `\`, because you end up with something like `file://D:\proj\report.html`, which uses backslashes, and file URIs are [supposed to use forward slashes](https://en.wikipedia.org/wiki/File_URI_scheme#:~:text=Forward%20slashes%20should%20be%20used%20to%20delimit%20paths.). Instead we can use the [`pathlib.Path.as_uri()`](https://docs.python.org/3/library/pathlib.html#pathlib.PurePath.as_uri) function to get a valid URI. While I was at it, I changed the rest of the file[s] to use `pathlib.Path` as well.