### PR TITLE
pip isn't a build dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,5 @@
 [build-system]
 requires = [
-  "pip >= 19.3.1",
   "setuptools >= 42",
   "setuptools_scm[toml] >= 3.5.0",
   "setuptools_scm_git_archive >= 1.1",


### PR DESCRIPTION
It's possible, and even desirable, to build modern Python code without pip, for example by using the `build` and `installer` packages.