### PR TITLE
upload json-formatted coverage reports

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -111,6 +111,12 @@ jobs:
         if: "contains(matrix.name, 'pypy3')"
         run: python -m tox -e ${{ steps.split-matrix-name.outputs._0}}
 
+      - uses: actions/upload-artifact@v3
+        with:
+          name: upload pytest timing reports as json
+          path: |
+            ./report-*.json
+
        # TODO: https://github.com/pytest-dev/pytest-html/issues/481
 #      - name: Upload coverage to codecov
 #        if: github.event.schedule == ''

--- a/tox.ini
+++ b/tox.ini
@@ -14,8 +14,8 @@ deps =
     pytest-rerunfailures
     pytest-mock
     ansi2html  # soft-dependency
+    pytest-json-report
     cov: pytest-cov
-    cov: pytest-json-report
 commands =
     !cov: python -X utf8 -m pytest -v -r a --durations=0 --color=yes --html={envlogdir}/report.html --self-contained-html --json-report --json-report-file={toxinidir}/report-{envname}.json {posargs}
     cov: python -X utf8 -m pytest -v -r a --durations=0 --color=yes --html={envlogdir}/report.html --self-contained-html --cov={envsitepackagesdir}/pytest_html --cov-report=term --cov-report=xml --json-report --json-report-file={toxinidir}/report-{envname}.json {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -15,9 +15,10 @@ deps =
     pytest-mock
     ansi2html  # soft-dependency
     cov: pytest-cov
+    cov: pytest-json-report
 commands =
     !cov: python -X utf8 -m pytest -v -r a --color=yes --html={envlogdir}/report.html --self-contained-html {posargs}
-    cov: python -X utf8 -m pytest -v -r a --color=yes --html={envlogdir}/report.html --self-contained-html --cov={envsitepackagesdir}/pytest_html --cov-report=term --cov-report=xml {posargs}
+    cov: python -X utf8 -m pytest -v -r a --color=yes --html={envlogdir}/report.html --self-contained-html --cov={envsitepackagesdir}/pytest_html --cov-report=term --cov-report=xml {posargs} --json-report --json-report-file={toxinidir}/report-{envname}.json {posargs}
 
 [testenv:linting]
 skip_install = True

--- a/tox.ini
+++ b/tox.ini
@@ -17,8 +17,8 @@ deps =
     cov: pytest-cov
     cov: pytest-json-report
 commands =
-    !cov: python -X utf8 -m pytest -v -r a --color=yes --html={envlogdir}/report.html --self-contained-html {posargs}
-    cov: python -X utf8 -m pytest -v -r a --color=yes --html={envlogdir}/report.html --self-contained-html --cov={envsitepackagesdir}/pytest_html --cov-report=term --cov-report=xml {posargs} --json-report --json-report-file={toxinidir}/report-{envname}.json {posargs}
+    !cov: python -X utf8 -m pytest -v -r a --durations=0 --color=yes --html={envlogdir}/report.html --self-contained-html --json-report --json-report-file={toxinidir}/report-{envname}.json {posargs}
+    cov: python -X utf8 -m pytest -v -r a --durations=0 --color=yes --html={envlogdir}/report.html --self-contained-html --cov={envsitepackagesdir}/pytest_html --cov-report=term --cov-report=xml --json-report --json-report-file={toxinidir}/report-{envname}.json {posargs}
 
 [testenv:linting]
 skip_install = True


### PR DESCRIPTION
As per [this comment](https://github.com/pytest-dev/pytest-html/issues/482#issuecomment-1126084182), add an upload of json-formatted coverage test reports so that this tool https://carreau.github.io/pytest-json-report-viewer/ can be used to analyze the time spent in tests