### PR TITLE
Enabled numeric sorting of the 'duration' column

### DIFF
--- a/src/pytest_html/html_report.py
+++ b/src/pytest_html/html_report.py
@@ -146,7 +146,7 @@ class HTMLReport:
         cells = [
             html.th("Result", class_="sortable result initial-sort", col="result"),
             html.th("Test", class_="sortable", col="name"),
-            html.th("Duration", class_="sortable", col="duration"),
+            html.th("Duration", class_="sortable duration", col="duration"),
             html.th("Links", class_="sortable links", col="links"),
         ]
         session.config.hook.pytest_html_results_table_header(cells=cells)

--- a/src/pytest_html/resources/main.js
+++ b/src/pytest_html/resources/main.js
@@ -32,6 +32,8 @@ function sortColumn(elem) {
         key = keyResult;
     } else if (elem.classList.contains('links')) {
         key = keyLink;
+    } else if (elem.classList.contains('duration')) {
+        key = keyDuration;
     } else {
         key = keyAlpha;
     }
@@ -178,6 +180,12 @@ function sort(items, keyFunc, reversed) {
 function keyAlpha(colIndex) {
     return function(elem) {
         return elem.childNodes[1].childNodes[colIndex].firstChild.data.toLowerCase();
+    };
+}
+
+function keyDuration(colIndex) {
+    return function(elem) {
+        return parseFloat(elem.childNodes[1].childNodes[colIndex].firstChild.data.toLowerCase());
     };
 }
 


### PR DESCRIPTION
This PR makes the "duration" column *numerically* sortable, such that, e.g., "2.0" appears *before* "100.0" and not after as in an alphabetic sort. I consider this very important to track down performance regressions as witnessed by test case execution times.