### PR TITLE
Add py as dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     package_data={"pytest_html": ["resources/*"]},
     entry_points={"pytest11": ["html = pytest_html.plugin"]},
     setup_requires=["setuptools_scm"],
-    install_requires=["pytest>=5.0,!=6.0.0", "pytest-metadata"],
+    install_requires=["py>=1.8.2", "pytest>=5.0,!=6.0.0", "pytest-metadata"],
     license="Mozilla Public License 2.0 (MPL 2.0)",
     keywords="py.test pytest html report",
     python_requires=">=3.6",


### PR DESCRIPTION
This dependency was implicitely set through pytest. With [1] the dependency was removed from pytest, so pytest-html fails with:

ModuleNotFoundError: No module named 'py.xml'; 'py' is not a package

Specify it explicitely as dependency to fix the issue.

[1] https://github.com/pytest-dev/pytest/commit/19dda7c9bdc8ef71c792e0f77a9595bfad8d9248

Signed-off-by: Erik Bloß <erik.bloss@smartmicro.de>