### PR TITLE
Fix: The report is saved without following the UTF-8 encoding

### DIFF
--- a/src/pytest_html/html_report.py
+++ b/src/pytest_html/html_report.py
@@ -256,10 +256,10 @@ class HTMLReport:
         if not self.self_contained:
             assets_dir.mkdir(parents=True, exist_ok=True)
 
-        self.logfile.write_text(report_content)
+        self.logfile.write_text(report_content, encoding="utf-8")
         if not self.self_contained:
             style_path = assets_dir / "style.css"
-            style_path.write_text(self.style_css)
+            style_path.write_text(self.style_css, encoding="utf-8")
 
     def _post_process_reports(self):
         for test_name, test_reports in self.reports.items():


### PR DESCRIPTION
HTML specifies the page charset="utf-8", but the file was not actually save according to utf-8


## How to reproduce 
a case
```python

def test_abc():
    print("这是UTF-8内容") 

```

## Report content
![image](https://user-images.githubusercontent.com/7629022/199986851-8417b553-2f28-410d-ab72-301ad83137d9.png)


## Cause analysis

This line of code declares that the HTML content is displayed in UTF-8, but in fact, the HTML file is not saved in UTF-8.

```html
<meta charset="utf-8"/>
```

To put it simply, the encoding of the file content is unknown, but it is emphasized to display according to UTF-8

#224