### PR TITLE
Switch to setuptools-scm >= 7.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,7 @@
 [build-system]
 requires = [
-  "setuptools >= 42",
-  "setuptools_scm[toml] >= 3.5.0",
-  "setuptools_scm_git_archive >= 1.1",
-  "wheel >= 0.33.6",
+  "setuptools >= 45",
+  "setuptools_scm[toml] >= 7.0.0",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     packages=["pytest_html"],
     package_data={"pytest_html": ["resources/*"]},
     entry_points={"pytest11": ["html = pytest_html.plugin"]},
-    setup_requires=["setuptools_scm"],
+    setup_requires=["setuptools_scm[toml]>=7.0.0"],
     install_requires=["py>=1.8.2", "pytest>=5.0,!=6.0.0", "pytest-metadata"],
     license="Mozilla Public License 2.0 (MPL 2.0)",
     keywords="py.test pytest html report",


### PR DESCRIPTION
pyproject.toml:
Switch to setuptools-scm >= 7.0.0, which allows dropping setuptools-scm-git-archive.
Remove wheel, as it is not required for building using PEP517 tooling (i.e. setuptools, setuptools-scm, build, installer).

setup.py:
Raise required setuptools-scm version to match the build-system requirements in pyproject.toml.