### PR TITLE
Large img preview in self-contained mode

### DIFF
--- a/src/layout/css/style.scss
+++ b/src/layout/css/style.scss
@@ -141,6 +141,7 @@ div.image {
 	margin-left: $spacing;
 	overflow: hidden;
 	width: $extra-media-width;
+	cursor: zoom-in;
 
 	img {
 		width: $extra-media-width;
@@ -213,5 +214,30 @@ div.video {
 	.desc.active & {
 		/*finish triangle*/
 		border-top: $triangle-width solid #999;
+	}
+}
+
+
+/*---------------------------
+ * 4. Zoom in self-contained
+ *---------------------------*/
+
+#large {
+	display: none;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+	z-index: 100;
+	position: fixed;
+	margin: auto;
+	overflow: scroll;
+	cursor: zoom-out;
+	background: rgba(0,0,0,0.5) no-repeat center;
+
+	img {
+		display: block;
+		margin-left: auto;
+		margin-right: auto;
 	}
 }

--- a/src/pytest_html/html_report.py
+++ b/src/pytest_html/html_report.py
@@ -201,6 +201,9 @@ class HTMLReport:
 
         body.extend(results)
 
+        if self.self_contained:
+            body.append(html.div(html.img(), id="large", onclick="zoomOut()"))
+
         doc = html.html(head, body)
 
         unicode_doc = "<!DOCTYPE html>\n{}".format(doc.unicode(indent=2))

--- a/src/pytest_html/resources/main.js
+++ b/src/pytest_html/resources/main.js
@@ -111,6 +111,23 @@ function addCollapse() {
     });
 }
 
+function zoomIn(event) {
+    const large = find('#large');
+    find('img', large).setAttribute('src', event.target.getAttribute('src'));
+    large.style.display = 'block';
+    large.scrollTop = 0;
+}
+
+function zoomOut() { // eslint-disable-line no-unused-vars
+    find('#large').style.display = 'none';
+}
+
+function addZoomIn() {
+    findAll('.image img').forEach(function(elem) {
+        elem.addEventListener('click', zoomIn);
+    });
+}
+
 function getQueryParameter(name) {
     const match = RegExp('[?&]' + name + '=([^&]*)').exec(window.location.search);
     return match && decodeURIComponent(match[1].replace(/\+/g, ' '));
@@ -120,6 +137,8 @@ function init () { // eslint-disable-line no-unused-vars
     resetSortHeaders();
 
     addCollapse();
+
+    addZoomIn();
 
     showFilters();
 

--- a/src/pytest_html/resources/style.css
+++ b/src/pytest_html/resources/style.css
@@ -117,6 +117,7 @@ div.image {
   margin-left: 5px;
   overflow: hidden;
   width: 320px;
+  cursor: zoom-in;
 }
 div.image img {
   width: 320px;
@@ -183,4 +184,27 @@ div.video video {
 .desc.active .sort-icon {
   /*finish triangle*/
   border-top: 8px solid #999;
+}
+
+/*---------------------------
+ * 4. Zoom in self-contained
+ *---------------------------*/
+#large {
+  display: none;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 100;
+  position: fixed;
+  margin: auto;
+  overflow: scroll;
+  cursor: zoom-out;
+  background: rgba(0,0,0,0.5) no-repeat center;
+}
+
+#large img {
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
 }


### PR DESCRIPTION
"ful-screen" preview of extra images attached to results for self-contained mode. Unlike image preview in normal mode implemented as part of page with little bit of js+css (likely also possible to implement via <a>, however adress line populated by base64 of the image would be really ugly in such case).