### PR TITLE
#559 Added missing encoding when writing Report

### DIFF
--- a/src/pytest_html/html_report.py
+++ b/src/pytest_html/html_report.py
@@ -256,7 +256,7 @@ class HTMLReport:
         if not self.self_contained:
             assets_dir.mkdir(parents=True, exist_ok=True)
 
-        self.logfile.write_text(report_content)
+        self.logfile.write_text(report_content, encoding="utf-8")
         if not self.self_contained:
             style_path = assets_dir / "style.css"
             style_path.write_text(self.style_css)


### PR DESCRIPTION
Encoding "utf-8" has been forgotten when migrating to `pathlib` as mentionned in issue #559.