### PR TITLE
fix: Report fails to render with pytest-xdist (1)

### DIFF
--- a/src/pytest_html/nextgen.py
+++ b/src/pytest_html/nextgen.py
@@ -239,14 +239,19 @@ class BaseReport:
 
     @pytest.hookimpl(trylast=True)
     def pytest_runtest_logreport(self, report):
-        data = self._config.hook.pytest_report_to_serializable(
+        serialized_report = self._config.hook.pytest_report_to_serializable(
             config=self._config, report=report
         )
+
+        data = {
+            "duration": serialized_report["duration"],
+            "when": serialized_report["when"],
+        }
 
         test_id = report.nodeid
         if report.when != "call":
             test_id += f"::{report.when}"
-            data["nodeid"] = test_id
+        data["nodeid"] = test_id
 
         # Order here matters!
         log = report.longreprtext or report.capstdout or "No log output captured."

--- a/testing/test_new.py
+++ b/testing/test_new.py
@@ -33,7 +33,6 @@ def run(pytester, path="report.html", *args):
     chrome_options = webdriver.ChromeOptions()
     chrome_options.add_argument("--headless")
     chrome_options.add_argument("--window-size=1920x1080")
-    # chrome_options.add_argument("--allow-file-access-from-files")
     driver = webdriver.Remote(
         command_executor="http://127.0.0.1:4444", options=chrome_options
     )
@@ -471,3 +470,8 @@ class TestHTML:
         assert_that(str(element)).is_equal_to(
             f'<video controls="">\n<source src="{src}" type="{mime_type}"/>\n</video>'
         )
+
+    def test_xdist(self, pytester):
+        pytester.makepyfile("def test_xdist(): pass")
+        page = run(pytester, "report.html", "-n1")
+        assert_results(page, passed=1)


### PR DESCRIPTION
The reason why the report fails to render when running with `pytest-xdist`, is that it adds a `node` attribute with a `WorkerController` object as its value.

This object is unserializable, so it fails when trying to convert the test data to JSON.

This is proposed solution 1.

Solution 2: #592 
Solution 3: #593 

There's also the option of making the WorkerController class serializable upstream. Ping @nicoddemus 