### PR TITLE
fix: Report fails to render with pytest-xdist (3)

### DIFF
--- a/src/pytest_html/nextgen.py
+++ b/src/pytest_html/nextgen.py
@@ -243,6 +243,9 @@ class BaseReport:
             config=self._config, report=report
         )
 
+        if "node" in data:
+            data["node"] = str(data["node"])
+
         test_id = report.nodeid
         if report.when != "call":
             test_id += f"::{report.when}"

--- a/testing/test_new.py
+++ b/testing/test_new.py
@@ -471,3 +471,8 @@ class TestHTML:
         assert_that(str(element)).is_equal_to(
             f'<video controls="">\n<source src="{src}" type="{mime_type}"/>\n</video>'
         )
+
+    def test_xdist(self, pytester):
+        pytester.makepyfile("def test_xdist(): pass")
+        page = run(pytester, "report.html", "-n1")
+        assert_results(page, passed=1)


### PR DESCRIPTION
See #591 for a detailed explanation.

This is proposed solution 3.