### PR TITLE
fix: set utf-8 encoding

### DIFF
--- a/src/pytest_html/html_report.py
+++ b/src/pytest_html/html_report.py
@@ -256,7 +256,7 @@ class HTMLReport:
         if not self.self_contained:
             assets_dir.mkdir(parents=True, exist_ok=True)
 
-        self.logfile.write_text(report_content)
+        self.logfile.write_text(report_content, encoding='utf-8')
         if not self.self_contained:
             style_path = assets_dir / "style.css"
             style_path.write_text(self.style_css)

--- a/src/pytest_html/html_report.py
+++ b/src/pytest_html/html_report.py
@@ -256,7 +256,7 @@ class HTMLReport:
         if not self.self_contained:
             assets_dir.mkdir(parents=True, exist_ok=True)
 
-        self.logfile.write_text(report_content, encoding='utf-8')
+        self.logfile.write_text(report_content, encoding="utf-8")
         if not self.self_contained:
             style_path = assets_dir / "style.css"
             style_path.write_text(self.style_css)


### PR DESCRIPTION
In Python 3, the default encoding is UTF-8. However, on Windows with Chinese (CP936/GBK), conflicts in encoding may occur since UTF-8 is not the default. This can cause HTML files written in GBK using the io module to be read as UTF-8 in browsers, resulting in garbled signals.

Signed-off-by: Next Alone <12210746+NextAlone@users.noreply.github.com>
