### PR TITLE
refactor: stop overwriting pytest data

### DIFF
--- a/src/pytest_html/resources/index.jinja2
+++ b/src/pytest_html/resources/index.jinja2
@@ -60,8 +60,8 @@
     <template id="template_results-table__head">
       <thead id="results-table-head">
         <tr>
-          <th class="sortable" data-column-type="outcome">Result</th>
-          <th class="sortable" data-column-type="nodeid">Test</th>
+          <th class="sortable" data-column-type="result">Result</th>
+          <th class="sortable" data-column-type="testid">Test</th>
           <th class="sortable" data-column-type="duration">Duration</th>
           <th>Links</th>
         </tr>

--- a/src/pytest_html/scripts/datamanager.js
+++ b/src/pytest_html/scripts/datamanager.js
@@ -6,7 +6,7 @@ class DataManager {
         const dataBlob = { ...data, tests: data.tests.map((test, index) => ({
             ...test,
             id: `test_${index}`,
-            collapsed: collapsedCategories.includes(test.outcome.toLowerCase()),
+            collapsed: collapsedCategories.includes(test.result.toLowerCase()),
         })) }
         this.data = { ...dataBlob }
         this.renderData = { ...dataBlob }

--- a/src/pytest_html/scripts/dom.js
+++ b/src/pytest_html/scripts/dom.js
@@ -52,7 +52,7 @@ const dom = {
         const header = listHeader.content.cloneNode(true)
         const sortAttr = storageModule.getSort()
         const sortAsc = JSON.parse(storageModule.getSortDirection())
-        const sortables = ['outcome', 'nodeid', 'duration']
+        const sortables = ['result', 'testId', 'duration']
 
         sortables.forEach((sortCol) => {
             if (sortCol === sortAttr) {
@@ -67,23 +67,23 @@ const dom = {
     },
     getListHeaderEmpty: () => listHeaderEmpty.content.cloneNode(true),
     getColGroup: () => templateCollGroup.content.cloneNode(true),
-    getResultTBody: ({ nodeid, id, longreprtext, duration, extras, resultsTableRow, tableHtml, outcome, collapsed }) => {
-        const outcomeLower = outcome.toLowerCase()
+    getResultTBody: ({ testId, id, log, duration, extras, resultsTableRow, tableHtml, result, collapsed }) => {
+        const resultLower = result.toLowerCase()
         let formattedDuration = formatDuration(duration)
         formattedDuration = formatDuration < 1 ? formattedDuration.ms : formattedDuration.formatted
         const resultBody = templateResult.content.cloneNode(true)
-        resultBody.querySelector('tbody').classList.add(outcomeLower)
-        resultBody.querySelector('.col-result').innerText = outcome
+        resultBody.querySelector('tbody').classList.add(resultLower)
+        resultBody.querySelector('.col-result').innerText = result
         resultBody.querySelector('.col-result').classList.add(`${collapsed ? 'expander' : 'collapser'}`)
         resultBody.querySelector('.col-result').dataset.id = id
-        resultBody.querySelector('.col-name').innerText = nodeid
+        resultBody.querySelector('.col-name').innerText = testId
 
         resultBody.querySelector('.col-duration').innerText = duration < 1 ? formatDuration(duration).ms : formatDuration(duration).formatted
 
 
-        if (longreprtext) {
-            // resultBody.querySelector('.log').innerText = longreprtext
-            resultBody.querySelector('.log').innerHTML = longreprtext
+        if (log) {
+            // resultBody.querySelector('.log').innerText = log
+            resultBody.querySelector('.log').innerHTML = log
         }
         // if (collapsed || !longreprtext) {
         if (collapsed) {

--- a/src/pytest_html/scripts/filter.js
+++ b/src/pytest_html/scripts/filter.js
@@ -2,7 +2,7 @@ const { manager } = require('./datamanager.js')
 const storageModule = require('./storage.js')
 
 const getFilteredSubSet = (filter) =>
-    manager.allData.tests.filter(({ outcome }) => filter.includes(outcome.toLowerCase()))
+    manager.allData.tests.filter(({ result }) => filter.includes(result.toLowerCase()))
 
 const doInitFilter = () => {
     const currentFilter = storageModule.getVisible()

--- a/src/pytest_html/scripts/main.js
+++ b/src/pytest_html/scripts/main.js
@@ -29,7 +29,7 @@ const renderStatic = () => {
 }
 
 const renderContent = (tests) => {
-    const renderSet = tests.filter(({ when, outcome }) => when === 'call' || outcome === 'Error' )
+    const renderSet = tests.filter(({ when, result }) => when === 'call' || result === 'Error' )
     const rows = renderSet.map(dom.getResultTBody)
     const table = document.querySelector('#results-table')
     removeChildren(table)
@@ -62,30 +62,30 @@ const renderContent = (tests) => {
 }
 
 const renderDerived = (tests, collectedItems, isFinished) => {
-    const renderSet = tests.filter(({ when, outcome }) => when === 'call' || outcome === 'Error')
+    const renderSet = tests.filter(({ when, result }) => when === 'call' || result === 'Error')
 
-    const possibleOutcomes = [
-        { outcome: 'passed', label: 'Passed' },
-        { outcome: 'skipped', label: 'Skipped' },
-        { outcome: 'failed', label: 'Failed' },
-        { outcome: 'error', label: 'Errors' },
-        { outcome: 'xfailed', label: 'Unexpected failures' },
-        { outcome: 'xpassed', label: 'Unexpected passes' },
-        { outcome: 'rerun', label: 'Reruns' },
+    const possibleResults = [
+        { result: 'passed', label: 'Passed' },
+        { result: 'skipped', label: 'Skipped' },
+        { result: 'failed', label: 'Failed' },
+        { result: 'error', label: 'Errors' },
+        { result: 'xfailed', label: 'Unexpected failures' },
+        { result: 'xpassed', label: 'Unexpected passes' },
+        { result: 'rerun', label: 'Reruns' },
     ]
 
     const currentFilter = getVisible()
-    possibleOutcomes.forEach(({ outcome, label }) => {
-        const count = renderSet.filter((test) => test.outcome.toLowerCase() === outcome).length
-        const input = document.querySelector(`input[data-test-result="${outcome}"]`)
-        document.querySelector(`.${outcome}`).innerText = `${count} ${label}`
+    possibleResults.forEach(({ result, label }) => {
+        const count = renderSet.filter((test) => test.result.toLowerCase() === result).length
+        const input = document.querySelector(`input[data-test-result="${result}"]`)
+        document.querySelector(`.${result}`).innerText = `${count} ${label}`
 
         input.disabled = !count
-        input.checked = currentFilter.includes(outcome)
+        input.checked = currentFilter.includes(result)
     })
 
-    const numberOfTests = renderSet.filter(({ outcome }) =>
-        ['Passed', 'Failed', 'XPassed', 'XFailed'].includes(outcome)).length
+    const numberOfTests = renderSet.filter(({ result }) =>
+        ['Passed', 'Failed', 'XPassed', 'XFailed'].includes(result)).length
 
     if (isFinished) {
         const accTime = tests.reduce((prev, { duration }) => prev + duration, 0)

--- a/src/pytest_html/scripts/storage.js
+++ b/src/pytest_html/scripts/storage.js
@@ -41,7 +41,7 @@ const setFilter = (currentFilter) => {
 
 const getSort = () => {
     const url = new URL(window.location.href)
-    return new URLSearchParams(url.search).get('sort') || 'outcome'
+    return new URLSearchParams(url.search).get('sort') || 'result'
 }
 const setSort = (type) => {
     const url = new URL(window.location.href)

--- a/testing/unittest.js
+++ b/testing/unittest.js
@@ -13,27 +13,27 @@ const setTestData = () => {
             [
                 {
                     'id': 'passed_1',
-                    'outcome': 'passed',
+                    'result': 'passed',
                 },
                 {
                     'id': 'failed_2',
-                    'outcome': 'failed',
+                    'result': 'failed',
                 },
                 {
                     'id': 'passed_3',
-                    'outcome': 'passed',
+                    'result': 'passed',
                 },
                 {
                     'id': 'passed_4',
-                    'outcome': 'passed',
+                    'result': 'passed',
                 },
                 {
                     'id': 'passed_5',
-                    'outcome': 'passed',
+                    'result': 'passed',
                 },
                 {
                     'id': 'passed_6',
-                    'outcome': 'passed',
+                    'result': 'passed',
                 },
             ],
     }
@@ -55,7 +55,7 @@ describe('Filter tests', () => {
 
             doInitFilter()
             expect(managerSpy.callCount).to.eql(1)
-            expect(dataModule.manager.testSubset.map(({ outcome }) => outcome)).to.eql([])
+            expect(dataModule.manager.testSubset.map(({ result }) => result)).to.eql([])
         })
         it('exclude passed', () => {
             getFilterMock = sinon.stub(storageModule, 'getVisible').returns(['failed'])
@@ -63,7 +63,7 @@ describe('Filter tests', () => {
 
             doInitFilter()
             expect(managerSpy.callCount).to.eql(1)
-            expect(dataModule.manager.testSubset.map(({ outcome }) => outcome)).to.eql(['failed'])
+            expect(dataModule.manager.testSubset.map(({ result }) => result)).to.eql(['failed'])
         })
     })
     describe('doFilter', () => {
@@ -76,7 +76,7 @@ describe('Filter tests', () => {
 
             doFilter('passed', true)
             expect(managerSpy.callCount).to.eql(1)
-            expect(dataModule.manager.testSubset.map(({ outcome }) => outcome)).to.eql([
+            expect(dataModule.manager.testSubset.map(({ result }) => result)).to.eql([
                 'passed', 'passed', 'passed', 'passed', 'passed',
             ])
         })
@@ -101,18 +101,18 @@ describe('Sort tests', () => {
 
             doInitSort()
             expect(managerSpy.callCount).to.eql(1)
-            expect(dataModule.manager.testSubset.map(({ outcome }) => outcome)).to.eql([
+            expect(dataModule.manager.testSubset.map(({ result }) => result)).to.eql([
                 'passed', 'failed', 'passed', 'passed', 'passed', 'passed',
             ])
         })
         it('has stored sort preference', () => {
-            sortMock = sinon.stub(storageModule, 'getSort').returns('outcome')
+            sortMock = sinon.stub(storageModule, 'getSort').returns('result')
             sortDirectionMock = sinon.stub(storageModule, 'getSortDirection').returns(false)
             managerSpy = sinon.spy(dataModule.manager, 'setRender')
 
             doInitSort()
             expect(managerSpy.callCount).to.eql(1)
-            expect(dataModule.manager.testSubset.map(({ outcome }) => outcome)).to.eql([
+            expect(dataModule.manager.testSubset.map(({ result }) => result)).to.eql([
                 'failed', 'passed', 'passed', 'passed', 'passed', 'passed',
             ])
         })
@@ -127,16 +127,16 @@ describe('Sort tests', () => {
         afterEach(() => [
             getSortMock, setSortMock, getSortDirectionMock, setSortDirection, managerSpy,
         ].forEach((fn) => fn.restore()))
-        it('sort on outcome', () => {
+        it('sort on result', () => {
             getSortMock = sinon.stub(storageModule, 'getSort').returns(null)
             setSortMock = sinon.stub(storageModule, 'setSort')
             getSortDirectionMock = sinon.stub(storageModule, 'getSortDirection').returns(null)
             setSortDirection = sinon.stub(storageModule, 'setSortDirection')
             managerSpy = sinon.spy(dataModule.manager, 'setRender')
 
-            doSort('outcome')
+            doSort('result')
             expect(managerSpy.callCount).to.eql(1)
-            expect(dataModule.manager.testSubset.map(({ outcome }) => outcome)).to.eql([
+            expect(dataModule.manager.testSubset.map(({ result }) => result)).to.eql([
                 'passed', 'passed', 'passed', 'passed', 'passed', 'failed',
             ])
         })


### PR DESCRIPTION
Previously we were overwriting some of the attributes coming out of pytest (like `nodeid`) and since this data is shared with other plugins, that's a bad idea.

This PR aims to fix that.