### PR TITLE
fix: Report fails to render with pytest-xdist

### DIFF
--- a/testing/test_integration.py
+++ b/testing/test_integration.py
@@ -471,3 +471,8 @@ class TestHTML:
         assert_that(str(element)).is_equal_to(
             f'<video controls="">\n<source src="{src}" type="{mime_type}"/>\n</video>'
         )
+
+    def test_xdist(self, pytester):
+        pytester.makepyfile("def test_xdist(): pass")
+        page = run(pytester, "report.html", "-n1")
+        assert_results(page, passed=1)


### PR DESCRIPTION
The original issue (detailed [here](https://github.com/pytest-dev/pytest-html/pull/591#issue-1619086434)) was fixed by: https://github.com/pytest-dev/pytest-html/pull/597

This PR just adds the test.