### PR TITLE
Fix: Table row hook

### DIFF
--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -197,20 +197,17 @@ adds a sortable time column, and removes the links column:
 .. code-block:: python
 
   from datetime import datetime
-  from py.xml import html
   import pytest
 
 
   def pytest_html_results_table_header(cells):
-      cells.insert(2, html.th("Description"))
-      cells.insert(1, html.th("Time", class_="sortable time", col="time"))
-      cells.pop()
+      cells.insert(2, "<th>Description</th>")
+      cells.insert(1, '<th class="sortable time" data-column-type="time">Time</th>')
 
 
   def pytest_html_results_table_row(report, cells):
-      cells.insert(2, html.td(report.description))
-      cells.insert(1, html.td(datetime.utcnow(), class_="col-time"))
-      cells.pop()
+      cells.insert(2, "<td>A description</td>")
+      cells.insert(1, '<td class="col-time">A time</td>')
 
 
   @pytest.hookimpl(hookwrapper=True)

--- a/src/pytest_html/scripts/dom.js
+++ b/src/pytest_html/scripts/dom.js
@@ -52,16 +52,27 @@ const dom = {
         const header = listHeader.content.cloneNode(true)
         const sortAttr = storageModule.getSort()
         const sortAsc = JSON.parse(storageModule.getSortDirection())
-        const sortables = ['result', 'testId', 'duration']
+
+        const regex = /data-column-type="(\w+)/
+        const cols = Object.values(resultsTableHeader).reduce((result, value) => {
+            if (value.includes("sortable")) {
+                const matches = regex.exec(value)
+                if (matches) {
+                    result.push(matches[1])
+                }
+            }
+            return result
+        }, [])
+        const sortables = ['result', 'testId', 'duration', ...cols]
+
+        // Add custom html from the pytest_html_results_table_header hook
+        insertAdditionalHTML(resultsTableHeader, header, 'th')
 
         sortables.forEach((sortCol) => {
             if (sortCol === sortAttr) {
                 header.querySelector(`[data-column-type="${sortCol}"]`).classList.add(sortAsc ? 'desc' : 'asc')
             }
         })
-
-        // Add custom html from the pytest_html_results_table_header hook
-        insertAdditionalHTML(resultsTableHeader, header, 'th')
 
         return header
     },

--- a/src/pytest_html/scripts/storage.js
+++ b/src/pytest_html/scripts/storage.js
@@ -1,15 +1,15 @@
-const possibleFiltes = ['passed', 'skipped', 'failed', 'error', 'xfailed', 'xpassed', 'rerun']
+const possibleFilters = ['passed', 'skipped', 'failed', 'error', 'xfailed', 'xpassed', 'rerun']
 
 const getVisible = () => {
     const url = new URL(window.location.href)
     const settings = new URLSearchParams(url.search).get('visible') || ''
     return settings ?
-        [...new Set(settings.split(',').filter((filter) => possibleFiltes.includes(filter)))] : possibleFiltes
+        [...new Set(settings.split(',').filter((filter) => possibleFilters.includes(filter)))] : possibleFilters
 }
 const hideCategory = (categoryToHide) => {
     const url = new URL(window.location.href)
     const visibleParams = new URLSearchParams(url.search).get('visible')
-    const currentVisible = visibleParams ? visibleParams.split(',') : [...possibleFiltes]
+    const currentVisible = visibleParams ? visibleParams.split(',') : [...possibleFilters]
     const settings = [...new Set(currentVisible)].filter((f) => f !== categoryToHide).join(',')
 
     url.searchParams.set('visible', settings)
@@ -21,15 +21,15 @@ const showCategory = (categoryToShow) => {
         return
     }
     const url = new URL(window.location.href)
-    const currentVisible = new URLSearchParams(url.search).get('visible')?.split(',') || [...possibleFiltes]
+    const currentVisible = new URLSearchParams(url.search).get('visible')?.split(',') || [...possibleFilters]
     const settings = [...new Set([categoryToShow, ...currentVisible])]
-    const noFilter = possibleFiltes.length === settings.length || !settings.length
+    const noFilter = possibleFilters.length === settings.length || !settings.length
 
     noFilter ? url.searchParams.delete('visible') : url.searchParams.set('visible', settings.join(','))
     history.pushState({}, null, unescape(url.href))
 }
 const setFilter = (currentFilter) => {
-    if (!possibleFiltes.includes(currentFilter)) {
+    if (!possibleFilters.includes(currentFilter)) {
         return
     }
     const url = new URL(window.location.href)


### PR DESCRIPTION
This PR fixes two things.

- We broke backwards compat where you could do `del cells[:]` to remove an item from the report. This is an interim solution for that.
- We also broke backwards compat where you could insert cells and have them sortable.