### PR TITLE
fix: Missing logging in report

### DIFF
--- a/src/pytest_html/scripts/datamanager.js
+++ b/src/pytest_html/scripts/datamanager.js
@@ -3,7 +3,7 @@ const { getCollapsedCategory } = require('./storage.js')
 class DataManager {
     setManager(data) {
         const collapsedCategories = [...getCollapsedCategory(), 'passed']
-        const dataBlob = { ...data, tests: data.tests.map((test, index) => ({
+        const dataBlob = { ...data, tests: Object.values(data.tests).flat().map((test, index) => ({
             ...test,
             id: `test_${index}`,
             collapsed: collapsedCategories.includes(test.result.toLowerCase()),

--- a/src/pytest_html/scripts/dom.js
+++ b/src/pytest_html/scripts/dom.js
@@ -84,6 +84,7 @@ const dom = {
         formattedDuration = formatDuration < 1 ? formattedDuration.ms : formattedDuration.formatted
         const resultBody = templateResult.content.cloneNode(true)
         resultBody.querySelector('tbody').classList.add(resultLower)
+        resultBody.querySelector('tbody').id = testId
         resultBody.querySelector('.col-result').innerText = result
         resultBody.querySelector('.col-result').classList.add(`${collapsed ? 'expander' : 'collapser'}`)
         resultBody.querySelector('.col-result').dataset.id = id

--- a/src/pytest_html/scripts/main.js
+++ b/src/pytest_html/scripts/main.js
@@ -29,8 +29,7 @@ const renderStatic = () => {
 }
 
 const renderContent = (tests) => {
-    const renderSet = tests.filter(({ when, result }) => when === 'call' || result === 'Error' )
-    const rows = renderSet.map(dom.getResultTBody)
+    const rows = tests.map(dom.getResultTBody)
     const table = document.querySelector('#results-table')
     removeChildren(table)
     const tableHeader = dom.getListHeader(manager.renderData)
@@ -62,8 +61,6 @@ const renderContent = (tests) => {
 }
 
 const renderDerived = (tests, collectedItems, isFinished) => {
-    const renderSet = tests.filter(({ when, result }) => when === 'call' || result === 'Error')
-
     const possibleResults = [
         { result: 'passed', label: 'Passed' },
         { result: 'skipped', label: 'Skipped' },
@@ -76,7 +73,7 @@ const renderDerived = (tests, collectedItems, isFinished) => {
 
     const currentFilter = getVisible()
     possibleResults.forEach(({ result, label }) => {
-        const count = renderSet.filter((test) => test.result.toLowerCase() === result).length
+        const count = tests.filter((test) => test.result.toLowerCase() === result).length
         const input = document.querySelector(`input[data-test-result="${result}"]`)
         document.querySelector(`.${result}`).innerText = `${count} ${label}`
 
@@ -84,7 +81,7 @@ const renderDerived = (tests, collectedItems, isFinished) => {
         input.checked = currentFilter.includes(result)
     })
 
-    const numberOfTests = renderSet.filter(({ result }) =>
+    const numberOfTests = tests.filter(({ result }) =>
         ['Passed', 'Failed', 'XPassed', 'XFailed'].includes(result)).length
 
     if (isFinished) {


### PR DESCRIPTION
The logging output/capture was broken in the legacy report, where "teardown" logs wasn't visible in the tests log output.