### PR TITLE
Fix: Order and layout of outcome summary

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ test = [
   "pre-commit>=2.17.0",
   "pytest-xdist>=2.4.0",
   "pytest-mock>=3.7.0",
+  "pytest-rerunfailures>=11.1.2",
   "selenium>=4.3.0",
   "tox>=3.24.5",
 ]

--- a/src/pytest_html/resources/index.jinja2
+++ b/src/pytest_html/resources/index.jinja2
@@ -97,13 +97,13 @@
         <div class="summary__spacer"></div>
           <div class="controls">
             <div class="filters">
-              <input checked="true" class="filter" data-test-result="error" name="filter_checkbox" type="checkbox"/><span class="error"></span>
               <input checked="true" class="filter" data-test-result="failed" name="filter_checkbox" type="checkbox"/><span class="failed"></span>
-              <input checked="true" class="filter" data-test-result="rerun" name="filter_checkbox" type="checkbox"/><span class="rerun"></span>
-              <input checked="true" class="filter" data-test-result="xfailed" name="filter_checkbox" type="checkbox"/><span class="xfailed"></span>
-              <input checked="true" class="filter" data-test-result="xpassed" name="filter_checkbox" type="checkbox"/><span class="xpassed"></span>
               <input checked="true" class="filter" data-test-result="passed" name="filter_checkbox" type="checkbox"/><span class="passed"></span>
               <input checked="true" class="filter" data-test-result="skipped" name="filter_checkbox" type="checkbox"/><span class="skipped"></span>
+              <input checked="true" class="filter" data-test-result="xfailed" name="filter_checkbox" type="checkbox"/><span class="xfailed"></span>
+              <input checked="true" class="filter" data-test-result="xpassed" name="filter_checkbox" type="checkbox"/><span class="xpassed"></span>
+              <input checked="true" class="filter" data-test-result="error" name="filter_checkbox" type="checkbox"/><span class="error"></span>
+              <input checked="true" class="filter" data-test-result="rerun" name="filter_checkbox" type="checkbox"/><span class="rerun"></span>
             </div>
             <div class="collapse">
               <button id="show_all_details">Show all details</button>&nbsp;/&nbsp;<button id="hide_all_details">Hide all details</button>

--- a/src/pytest_html/scripts/main.js
+++ b/src/pytest_html/scripts/main.js
@@ -65,7 +65,12 @@ const renderDerived = (tests, collectedItems, isFinished) => {
     possibleResults.forEach(({ result, label }) => {
         const count = tests.filter((test) => test.result.toLowerCase() === result).length
         const input = document.querySelector(`input[data-test-result="${result}"]`)
+        const lastInput = document.querySelector(`input[data-test-result="${result}"]:last-of-type`)
         document.querySelector(`.${result}`).innerText = `${count} ${label}`
+        // add a comma and whitespace between the results
+        if (input !== lastInput) {
+            document.querySelector(`.${result}`).innerText += ', '
+        }
 
         input.disabled = !count
         input.checked = currentFilter.includes(result)

--- a/testing/test_integration.py
+++ b/testing/test_integration.py
@@ -81,7 +81,7 @@ def assert_results(
         if isinstance(number, int):
             number_of_tests += number
             result = get_text(page, f"span[class={outcome}]")
-            assert_that(result).is_equal_to(f"{number} {OUTCOMES[outcome]}")
+            assert_that(result).matches(rf"{number} {OUTCOMES[outcome]}")
 
 
 def get_element(page, selector):


### PR DESCRIPTION
Making the order of the outcomes in the summary the same as `pytest` has in the terminal.