### PR TITLE
Fix: Handle appends on table hooks

### DIFF
--- a/src/pytest_html/scripts/dom.js
+++ b/src/pytest_html/scripts/dom.js
@@ -1,5 +1,5 @@
 const storageModule = require('./storage.js')
-const { formatDuration } = require('./utils.js')
+const { formatDuration, transformTableObj } = require('./utils.js')
 const mediaViewer = require('./mediaviewer.js')
 const templateEnvRow = document.querySelector('#template_environment_row')
 const templateCollGroup = document.querySelector('#template_table-colgroup')
@@ -28,9 +28,9 @@ const findAll = (selector, elem) => {
     return [...elem.querySelectorAll(selector)]
 }
 
-const insertAdditionalHTML = (html, element, selector) => {
+const insertAdditionalHTML = (html, element, selector, position = 'beforebegin') => {
     Object.keys(html).map((key) => {
-        element.querySelectorAll(selector).item(key).insertAdjacentHTML('beforebegin', html[key])
+        element.querySelectorAll(selector).item(key).insertAdjacentHTML(position, html[key])
     })
 }
 
@@ -66,7 +66,9 @@ const dom = {
         const sortables = ['result', 'testId', 'duration', ...cols]
 
         // Add custom html from the pytest_html_results_table_header hook
-        insertAdditionalHTML(resultsTableHeader, header, 'th')
+        const headers = transformTableObj(resultsTableHeader)
+        insertAdditionalHTML(headers.inserts, header, 'th')
+        insertAdditionalHTML(headers.appends, header, 'tr', 'beforeend')
 
         sortables.forEach((sortCol) => {
             if (sortCol === sortAttr) {
@@ -91,7 +93,6 @@ const dom = {
         resultBody.querySelector('.col-name').innerText = testId
 
         resultBody.querySelector('.col-duration').innerText = duration < 1 ? formatDuration(duration).ms : formatDuration(duration).formatted
-
 
         if (log) {
             resultBody.querySelector('.log').innerHTML = log
@@ -126,7 +127,9 @@ const dom = {
         mediaViewer.setUp(resultBody, media)
 
         // Add custom html from the pytest_html_results_table_row hook
-        resultsTableRow && insertAdditionalHTML(resultsTableRow, resultBody, 'td')
+        const rows = transformTableObj(resultsTableRow)
+        resultsTableRow && insertAdditionalHTML(rows.inserts, resultBody, 'td')
+        resultsTableRow && insertAdditionalHTML(rows.appends, resultBody, 'tr', 'beforeend')
 
         // Add custom html from the pytest_html_results_table_html hook
         tableHtml?.forEach((item) => {

--- a/src/pytest_html/scripts/utils.js
+++ b/src/pytest_html/scripts/utils.js
@@ -21,4 +21,19 @@ const formatDuration = ( totalSeconds ) => {
     }
 }
 
-module.exports = { formatDuration }
+const transformTableObj = (obj) => {
+    const appends = {}
+    const inserts = {}
+    for (const key in obj) {
+        key.startsWith("Z") ? appends[key] = obj[key] : inserts[key] = obj[key]
+    }
+    return {
+        appends,
+        inserts,
+    }
+}
+
+module.exports = {
+    formatDuration,
+    transformTableObj,
+}

--- a/src/pytest_html/table.py
+++ b/src/pytest_html/table.py
@@ -29,6 +29,10 @@ class Html(Table):
 
 
 class Cell(Table):
+    def __init__(self):
+        super().__init__()
+        self._append_counter = 0
+
     def __setitem__(self, key, value):
         warnings.warn(
             "list-type assignment is deprecated and support "
@@ -37,6 +41,12 @@ class Cell(Table):
             DeprecationWarning,
         )
         self.insert(key, value)
+
+    def append(self, item):
+        # We need a way of separating inserts from appends in JS,
+        # hence the "Z" prefix
+        self.insert(f"Z{self._append_counter}", item)
+        self._append_counter += 1
 
     def insert(self, index, html):
         # backwards-compat

--- a/testing/unittest.js
+++ b/testing/unittest.js
@@ -2,7 +2,7 @@ const { expect } = require('chai')
 const sinon = require('sinon')
 const { doInitFilter, doFilter } = require('../src/pytest_html/scripts/filter.js')
 const { doInitSort, doSort } = require('../src/pytest_html/scripts/sort.js')
-const { formatDuration } = require('../src/pytest_html/scripts/utils.js')
+const { formatDuration, transformTableObj } = require('../src/pytest_html/scripts/utils.js')
 const dataModule = require('../src/pytest_html/scripts/datamanager.js')
 const storageModule = require('../src/pytest_html/scripts/storage.js')
 
@@ -153,6 +153,23 @@ describe('utils tests', () => {
         it('handles larger durations', () => {
             expect(formatDuration(1.234).formatted).to.eql('00:00:01')
             expect(formatDuration(12345.678).formatted).to.eql('03:25:46')
+        })
+    })
+    describe('transformTableObj', () => {
+        it('handles empty object', () => {
+            expect(transformTableObj({})).to.eql({appends: {}, inserts: {}})
+        })
+        it('handles no appends', () => {
+            const expected = {1: "hello", 2: "goodbye"}
+            expect(transformTableObj(expected)).to.eql({appends: {}, inserts: expected})
+        })
+        it('handles no inserts', () => {
+            const expected = {"Z1": "hello", "Z2": "goodbye"}
+            expect(transformTableObj(expected)).to.eql({appends: expected, inserts: {}})
+        })
+        it('handles both', () => {
+            const expected = {appends: {"Z1": "hello", "Z2": "goodbye"}, inserts: {1: "mee", 2: "moo"}}
+            expect(transformTableObj({...expected.appends, ...expected.inserts})).to.eql(expected)
         })
     })
 })


### PR DESCRIPTION
Since `cells` was of type `list` in the legacy report, people might also use `appends` (apart from list assignment and `insert`) so for backwards compat, we'll add support for now.

This will be deprecated once we've decided on what the "Table" API should look like.