### PR TITLE
Fix: Color E(xecption) lines in the log red

### DIFF
--- a/src/pytest_html/scripts/dom.js
+++ b/src/pytest_html/scripts/dom.js
@@ -92,9 +92,10 @@ const dom = {
 
         resultBody.querySelector('.col-duration').innerText = duration < 1 ? formatDuration(duration).ms : formatDuration(duration).formatted
 
-
         if (log) {
-            resultBody.querySelector('.log').innerHTML = log
+            // Wrap lines starting with "E" with span.error to color those lines red
+            const wrappedLog = log.replace(/^E.*$/gm, (match) => `<span class="error">${match}</span>`)
+            resultBody.querySelector('.log').innerHTML = wrappedLog
         } else {
             resultBody.querySelector('.log').remove()
         }

--- a/testing/test_integration.py
+++ b/testing/test_integration.py
@@ -206,6 +206,9 @@ class TestHTML:
         page = run(pytester)
         assert_results(page, failed=1)
         assert_that(get_log(page)).contains("AssertionError")
+        assert_that(get_text(page, ".summary div[class='log'] span.error")).matches(
+            r"^E\s+assert False$"
+        )
 
     def test_xfail(self, pytester):
         reason = str(random.random())


### PR DESCRIPTION
In the legacy report any log lines starting with `E` was colored red, which aided readability.

This was lost in the rewrite, so let's re-add it.