### PR TITLE
Fix: results table html hook

### DIFF
--- a/src/pytest_html/table.py
+++ b/src/pytest_html/table.py
@@ -13,23 +13,9 @@ class Table:
     def html(self):
         return self._html
 
-
-class Html(Table):
-    def __init__(self):
-        super().__init__()
-        self.html.setdefault("html", [])
-        self._replace_log = False
-
-    def __delitem__(self, key):
-        # This means the log should be removed
-        self._replace_log = True
-
-    @property
-    def replace_log(self):
-        return self._replace_log
-
-    def append(self, html):
-        self.html["html"].append(html)
+    @html.setter
+    def html(self, value):
+        self._html = value
 
 
 class Cell(Table):


### PR DESCRIPTION
Not a 100% 1-to-1 with the Legacy report, but good enough.

In Legacy the `data` argument also contained any HTML added via `extras.HTML`, but since that is also under user control with even more granular control - any modifications previously done using the hook, can be done directly to the extras object instead. 

Closes: #667 
