### PR TITLE
Fix: Logging issues with teardown

### DIFF
--- a/src/pytest_html/basereport.py
+++ b/src/pytest_html/basereport.py
@@ -248,15 +248,17 @@ def _process_logs(report):
     log = []
     if report.longreprtext:
         log.append(report.longreprtext.replace("<", "&lt;").replace(">", "&gt;") + "\n")
-    for section in report.sections:
-        header, content = section
-        log.append(f"{' ' + header + ' ':-^80}\n{content}")
+    # Don't add captured output to reruns
+    if report.outcome != "rerun":
+        for section in report.sections:
+            header, content = section
+            log.append(f"{' ' + header + ' ':-^80}\n{content}")
 
-        # weird formatting related to logs
-        if "log" in header:
-            log.append("")
-            if "call" in header:
+            # weird formatting related to logs
+            if "log" in header:
                 log.append("")
+                if "call" in header:
+                    log.append("")
     if not log:
         log.append("No log output captured.")
     return log

--- a/src/pytest_html/report_data.py
+++ b/src/pytest_html/report_data.py
@@ -67,7 +67,7 @@ class ReportData:
     def add_test(self, test_data, report, logs):
         # regardless of pass or fail we must add teardown logging to "call"
         if report.when == "teardown":
-            self.update_test_log(report)
+            self.append_teardown_log(report)
 
         # passed "setup" and "teardown" are not added to the html
         if report.when == "call" or (
@@ -79,12 +79,13 @@ class ReportData:
 
         return False
 
-    def update_test_log(self, report):
+    def append_teardown_log(self, report):
         log = []
-        for test in self._data["tests"][report.nodeid]:
-            if test["testId"] == report.nodeid and "log" in test:
-                for section in report.sections:
-                    header, content = section
-                    if "teardown" in header:
-                        log.append(f"{' ' + header + ' ':-^80}\n{content}")
-                test["log"] += _handle_ansi("\n".join(log))
+        if self._data["tests"][report.nodeid]:
+            # Last index is "call"
+            test = self._data["tests"][report.nodeid][-1]
+            for section in report.sections:
+                header, content = section
+                if "teardown" in header:
+                    log.append(f"{' ' + header + ' ':-^80}\n{content}")
+            test["log"] += _handle_ansi("\n".join(log))


### PR DESCRIPTION
There seems to be multiple issues with `pytest-rerunfailures` and/or `pytest` related to captured logs.

More info here: https://github.com/pytest-dev/pytest-rerunfailures/pull/124

Until they have been fixed or I've figured out exactly what the problem is, we won't attach logs to "reruns".

Not that there's still an issue where "teardown" logs are added multiple times in the output from `pytest`. Which in turn means that's what ends up in the report.