### PR TITLE
Fix results table modification documentation

### DIFF
--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -200,6 +200,7 @@ adds a sortable time column, and removes the links column:
 .. code-block:: python
 
   import pytest
+  from datetime import datetime
 
 
   def pytest_html_results_table_header(cells):
@@ -208,8 +209,8 @@ adds a sortable time column, and removes the links column:
 
 
   def pytest_html_results_table_row(report, cells):
-      cells.insert(2, "<td>A description</td>")
-      cells.insert(1, '<td class="col-time">A time</td>')
+      cells.insert(2, f"<td>{report.description}</td>")
+      cells.insert(1, f'<td class="col-time">{datetime.utcnow()}</td>')
 
 
   @pytest.hookimpl(hookwrapper=True)


### PR DESCRIPTION
The example results table modification shown in the docs is broken since https://github.com/pytest-dev/pytest-html/pull/599, some hardcoded strings are used instead of the dynamically generated report entry data.