### PR TITLE
fix: Revert report generation to full run

### DIFF
--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -9,6 +9,18 @@ of a less permissive license, this package is not included as a dependency. If
 you have this package installed, then ANSI codes will be converted to HTML in
 your report.
 
+Report streaming
+----------------
+
+In order to stream the result, basically generating the report for each finished test
+instead of waiting until the full run is finished, you can set the ``generate_report_on_test``
+ini-value:
+
+.. code-block:: ini
+
+  [pytest]
+  generate_report_on_test = True
+
 Creating a self-contained report
 --------------------------------
 

--- a/src/pytest_html/basereport.py
+++ b/src/pytest_html/basereport.py
@@ -14,7 +14,6 @@ import pytest
 
 from pytest_html import __version__
 from pytest_html import extras
-from pytest_html.util import cleanup_unserializable
 
 
 class BaseReport:
@@ -49,7 +48,7 @@ class BaseReport:
 
     def _generate_report(self, self_contained=False):
         generated = datetime.datetime.now()
-        test_data = cleanup_unserializable(self._report.data)
+        test_data = self._report.data
         test_data = json.dumps(test_data)
         rendered_report = self._template.render(
             title=self._report.title,

--- a/src/pytest_html/basereport.py
+++ b/src/pytest_html/basereport.py
@@ -239,7 +239,8 @@ class BaseReport:
                 dur = test_duration if when == "call" else each.duration
                 self._process_report(each, dur)
 
-        self._generate_report()
+        if self._config.getini("generate_report_on_test"):
+            self._generate_report()
 
     def _process_report(self, report, duration):
         outcome = _process_outcome(report)

--- a/src/pytest_html/plugin.py
+++ b/src/pytest_html/plugin.py
@@ -72,6 +72,13 @@ def pytest_addoption(parser):
         default="result",
         help="column to initially sort on.",
     )
+    parser.addini(
+        "generate_report_on_test",
+        type="bool",
+        default=False,
+        help="the HTML report will be generated after each test "
+        "instead of at the end of the run.",
+    )
 
 
 def pytest_configure(config):

--- a/src/pytest_html/util.py
+++ b/src/pytest_html/util.py
@@ -1,10 +1,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-import json
 from functools import partial
-from typing import Any
-from typing import Dict
 
 from jinja2 import Environment
 from jinja2 import FileSystemLoader
@@ -21,18 +18,6 @@ except ImportError:
 
     _handle_ansi = _remove_ansi_escape_sequences
     _ansi_styles = []
-
-
-def cleanup_unserializable(d: Dict[str, Any]) -> Dict[str, Any]:
-    """Return new dict with entries that are not json serializable by their str()."""
-    result = {}
-    for k, v in d.items():
-        try:
-            json.dumps({k: v})
-        except TypeError:
-            v = str(v)
-        result[k] = v
-    return result
 
 
 def _read_template(search_paths, template_name="index.jinja2"):


### PR DESCRIPTION
Two changes in this PR:

- Make generating the HTLM report after each test optional, reverting to the behaviour of v3 and earlier versions.

- Remove the `cleanup_unserializable` function in effort to improve performance. If this brings any issues, we can make a more conscious effort of handling those errors.

Fixes: #751 
Fixes: #742 
Fixes: #741 
  