### PR TITLE
Fix report template

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,6 +63,15 @@ repos:
         language: python
         additional_dependencies: [pygments, restructuredtext_lint]
 
+  - repo: local
+    hooks:
+      - id: djlint
+        name: djlint
+        entry: djlint
+        files: \.jinja2$
+        language: python
+        additional_dependencies: [djlint]
+
   - repo: https://github.com/elidupuis/mirrors-sass-lint
     rev: "5cc45653263b423398e4af2561fae362903dd45d"
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,10 +95,6 @@ version-file = "src/pytest_html/__version.py"
 [tool.hatch.build.hooks.custom]
 path = "scripts/npm.py"
 
-[tool.djlint]
-profile="jinja"
-ignore="H005,H016,H030,H031,H006,H013"
-
 [tool.mypy]
 check_untyped_defs = false         # TODO
 disallow_any_generics = true
@@ -116,3 +112,6 @@ warn_return_any = true
 warn_unreachable = true
 warn_unused_configs = true
 
+[tool.djlint]
+profile = "jinja"
+ignore = "H005,H016,H030,H031,H006,H013"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,3 +100,4 @@ path = "scripts/npm.py"
 
 [tool.djlint]
 profile="jinja"
+ignore="H005,H016,H030,H031,H006,H013"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,3 +97,6 @@ version-file = "src/pytest_html/__version.py"
 
 [tool.hatch.build.hooks.custom]
 path = "scripts/npm.py"
+
+[tool.djlint]
+profile="jinja"

--- a/src/pytest_html/resources/index.jinja2
+++ b/src/pytest_html/resources/index.jinja2
@@ -82,7 +82,7 @@
         <div class="controls">
           <div class="filters">
           {%- for result, values in outcomes.items() %}
-            <input checked="true" class="filter" name="filter_checkbox" type="checkbox" data-test-result="{{ result }}" {{ "disabled" if values["value"] == 0 }}/>
+            <input checked="true" class="filter" name="filter_checkbox" type="checkbox" data-test-result="{{ result }}" {{ "disabled" if values["value"] == 0 }}>
             <span class="{{ result }}">{{ values["value"] }} {{ values["label"] }}{{ "," if result != "rerun" }}</span>
           {%- endfor %}
           </div>

--- a/src/pytest_html/resources/index.jinja2
+++ b/src/pytest_html/resources/index.jinja2
@@ -29,8 +29,9 @@
     <template id="template_results-table__body--empty">
       <tbody class="results-table-row">
         <tr id="not-found-message">
-          <td colspan="{{ table_head|length }}">No results found. Check the filters.</th>
+          <td colspan="{{ table_head|length }}">No results found. Check the filters.</td>
         </tr>
+      </tbody>
     </template>
     <template id="template_results-table__tbody">
       <tbody class="results-table-row">
@@ -41,14 +42,14 @@
             <div class="extraHTML"></div>
             <div class="media">
               <div class="media-container">
-                  <div class="media-container__nav--left"><</div>
+                  <div class="media-container__nav--left">&lt;</div>
                   <div class="media-container__viewport">
                     <img src="" />
                     <video controls>
                       <source src="" type="video/mp4">
                     </video>
                   </div>
-                  <div class="media-container__nav--right">></div>
+                  <div class="media-container__nav--right">&gt;</div>
                 </div>
                 <div class="media__name"></div>
                 <div class="media__counter"></div>


### PR DESCRIPTION
## Motivation

My colleague had issues with displaying generated reports:

The report was correctly displayed on:
- my Linux/Firefox machine.
- his Windows/Edge

The report had no content or even showed blank page on:
- on his computer windows/firefox
- on his computer windows/chrome

When I checked the generated report file I noticed that:
- some tags were not properly closed
- some special characters are not escaped properly

### Issues
Examples

- https://github.com/pytest-dev/pytest-html/blob/4b714aa558b1f7b8af1035033e4e94601ef75c4b/src/pytest_html/resources/index.jinja2#L32

- https://github.com/pytest-dev/pytest-html/blob/4b714aa558b1f7b8af1035033e4e94601ef75c4b/src/pytest_html/resources/index.jinja2#L51

### Misc

This PR also adds `djlint` to pre-commit hook.

## Changes

### Fixed

- Fixed tags in report template.

### Added

- Added pre-commit hook to validate report template.
