### PR TITLE
Fix for #806 (if results table order changed, hide/show details hover over broken)

### DIFF
--- a/src/pytest_html/scripts/dom.js
+++ b/src/pytest_html/scripts/dom.js
@@ -57,10 +57,10 @@ const dom = {
         }
 
         if (collapsed) {
-            resultBody.querySelector('.collapsible > td')?.classList.add('collapsed')
+            resultBody.querySelector('.collapsible > col-result')?.classList.add('collapsed')
             resultBody.querySelector('.extras-row').classList.add('hidden')
         } else {
-            resultBody.querySelector('.collapsible > td')?.classList.remove('collapsed')
+            resultBody.querySelector('.collapsible > col-result')?.classList.remove('collapsed')
         }
 
         const media = []

--- a/src/pytest_html/scripts/dom.js
+++ b/src/pytest_html/scripts/dom.js
@@ -57,10 +57,10 @@ const dom = {
         }
 
         if (collapsed) {
-            resultBody.querySelector('.collapsible > col-result')?.classList.add('collapsed')
+            resultBody.querySelector('.collapsible > .col-result')?.classList.add('collapsed')
             resultBody.querySelector('.extras-row').classList.add('hidden')
         } else {
-            resultBody.querySelector('.collapsible > col-result')?.classList.remove('collapsed')
+            resultBody.querySelector('.collapsible > .col-result')?.classList.remove('collapsed')
         }
 
         const media = []

--- a/testing/test_integration.py
+++ b/testing/test_integration.py
@@ -870,6 +870,24 @@ class TestHTML:
         for row, expected in zip(result, order):
             assert_that(row.string).contains(expected)
 
+    def test_collapsed_class_when_results_table_order_changed(self, pytester):
+        pytester.makeconftest(
+            """
+            def pytest_html_results_table_header(cells):
+                cells.append(cells.pop(0))
+
+            def pytest_html_results_table_row(report, cells):
+                cells.append(cells.pop(0))
+        """
+        )
+        pytester.makepyfile("def test_pass(): pass")
+        page = run(pytester)
+        assert_results(page, passed=1)
+
+        assert_that(
+            get_text(page, "#results-table td[class='col-result collapsed']")
+        ).is_true()
+
 
 class TestLogCapturing:
     LOG_LINE_REGEX = r"\s+this is {}"


### PR DESCRIPTION
If you move 'col-result' to right hand side in results-table, it always shows 'hide details' even details are already collapsed.

the reason is, col-result is not the first td element of the results-table anymore and therefore it adds collapsible class to first td element.

because of this reason, below function does not work:
```
.col-result:hover::after {
  content: " (hide details)";
}

.col-result.collapsed:hover::after {
  content: " (show details)";
}

```

changing '.collapsible > td' to '.collapsible > col-result' fix this problem.