### PR TITLE
Add expand_logs ini option

### DIFF
--- a/src/pytest_html/plugin.py
+++ b/src/pytest_html/plugin.py
@@ -73,6 +73,12 @@ def pytest_addoption(parser):
         help="column to initially sort on.",
     )
     parser.addini(
+        "expand_logs",
+        type="string",
+        default=False,
+        help="expand all logs by default.",
+    )
+    parser.addini(
         "generate_report_on_test",
         type="bool",
         default=False,

--- a/src/pytest_html/report_data.py
+++ b/src/pytest_html/report_data.py
@@ -61,6 +61,9 @@ class ReportData:
         initial_sort = config.getini("initial_sort")
         self._data["initialSort"] = initial_sort
 
+        expand_logs = config.getini("expand_logs")
+        self._data["expandLogs"] = expand_logs
+
     @property
     def additional_summary(self):
         return self._additional_summary

--- a/src/pytest_html/scripts/datamanager.js
+++ b/src/pytest_html/scripts/datamanager.js
@@ -57,6 +57,10 @@ class DataManager {
     get initialSort() {
         return this.data.initialSort
     }
+
+    get expandLogs() {
+        return this.data.expandLogs
+    }
 }
 
 module.exports = {

--- a/src/pytest_html/scripts/main.js
+++ b/src/pytest_html/scripts/main.js
@@ -6,6 +6,7 @@ const {
     getVisible,
     getCollapsedIds,
     setCollapsedIds,
+    getExpandLogs,
     getSort,
     getSortDirection,
     possibleFilters,
@@ -47,10 +48,12 @@ const addItemToggleListener = (elem) => {
 
 const renderContent = (tests) => {
     const sortAttr = getSort(manager.initialSort)
+    const expandLogs = getExpandLogs(manager.expandLogs)
     const sortAsc = JSON.parse(getSortDirection())
     const rows = tests.map(dom.getResultTBody)
     const table = document.getElementById('results-table')
     const tableHeader = document.getElementById('results-table-head')
+    const clickEvent = new Event('click');
 
     const newTable = document.createElement('table')
     newTable.id = 'results-table'
@@ -70,6 +73,9 @@ const renderContent = (tests) => {
                 find('.logexpander', row).addEventListener('click',
                     (evt) => evt.target.parentNode.classList.toggle('expanded'),
                 )
+                if (expandLogs) {
+                    find('.logexpander', row).dispatchEvent(clickEvent)
+                }
                 newTable.appendChild(row)
             }
         })

--- a/src/pytest_html/scripts/main.js
+++ b/src/pytest_html/scripts/main.js
@@ -53,7 +53,7 @@ const renderContent = (tests) => {
     const rows = tests.map(dom.getResultTBody)
     const table = document.getElementById('results-table')
     const tableHeader = document.getElementById('results-table-head')
-    const clickEvent = new Event('click');
+    const clickEvent = new Event('click')
 
     const newTable = document.createElement('table')
     newTable.id = 'results-table'

--- a/src/pytest_html/scripts/storage.js
+++ b/src/pytest_html/scripts/storage.js
@@ -48,7 +48,7 @@ const showCategory = (categoryToShow) => {
 }
 
 const getExpandLogs = (expandLogs) => {
-    if (expandLogs === "true") {
+    if (expandLogs === 'true') {
         return true
     }
     if (expandLogs) {

--- a/src/pytest_html/scripts/storage.js
+++ b/src/pytest_html/scripts/storage.js
@@ -47,6 +47,16 @@ const showCategory = (categoryToShow) => {
     window.history.pushState({}, null, unescape(url.href))
 }
 
+const getExpandLogs = (expandLogs) => {
+    if (expandLogs === "true") {
+        return true
+    }
+    if (expandLogs) {
+        return true
+    }
+    return false
+}
+
 const getSort = (initialSort) => {
     const url = new URL(window.location.href)
     let sort = new URLSearchParams(url.search).get('sort')
@@ -99,6 +109,7 @@ module.exports = {
     showCategory,
     getCollapsedIds,
     setCollapsedIds,
+    getExpandLogs,
     getSort,
     setSort,
     getSortDirection,


### PR DESCRIPTION
Is some cases it is more convenient to expand all logs by default,
e.g., if you have several tests with long logs and you need to find
something.