### PR TITLE
Generate html report using collection modifiers through markers

### DIFF
--- a/src/pytest_html/basereport.py
+++ b/src/pytest_html/basereport.py
@@ -180,6 +180,16 @@ class BaseReport:
 
     @pytest.hookimpl(trylast=True)
     def pytest_sessionfinish(self, session):
+        generate_with_tags = session.config.getoption("generate_reports_with_tags")
+        self._report.set_data("environment", self._generate_environment())
+        session.config.hook.pytest_html_report_title(report=self._report)
+        if generate_with_tags:
+            headers = self._report.table_header
+            session.config.hook.pytest_html_results_table_header(cells=headers)
+            self._report.table_header = _fix_py(headers)
+            self._report.running_state = "started"
+            self._generate_report()
+            
         session.config.hook.pytest_html_results_summary(
             prefix=self._report.additional_summary["prefix"],
             summary=self._report.additional_summary["summary"],

--- a/src/pytest_html/plugin.py
+++ b/src/pytest_html/plugin.py
@@ -79,6 +79,12 @@ def pytest_addoption(parser):
         help="the HTML report will be generated after each test "
         "instead of at the end of the run.",
     )
+    group.addoption(
+        "--generate_reports_with_tags",
+        action="store_true",
+        help="the HTML report will be generated while running with tags",
+
+    ) 
 
 
 def pytest_configure(config):


### PR DESCRIPTION
Since pytest_html_results_table_header hook is not invoking in pytest-html 4.1.1 when running tests with markers. With pytest_html_results_table_header hook I’m trying to insert a snapshot column for failed test , since the table is not properly customized I'm getting an empty report. This hook was invoked in the previous version and is still invoking in 4.1.1 when running tests without tags. The lack of this hook prevents proper table customization, resulting in an empty table. So to generate html report using collection modifiers through markers this change is required.