### PR TITLE
Removing links column was removed in the example code. Re-added!

### DIFF
--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -218,11 +218,13 @@ adds a sortable time column, and removes the links column:
   def pytest_html_results_table_header(cells):
       cells.insert(2, "<th>Description</th>")
       cells.insert(1, '<th class="sortable time" data-column-type="time">Time</th>')
+      cells.pop()
 
 
   def pytest_html_results_table_row(report, cells):
       cells.insert(2, f"<td>{report.description}</td>")
       cells.insert(1, f'<td class="col-time">{datetime.utcnow()}</td>')
+      cells.pop()
 
 
   @pytest.hookimpl(hookwrapper=True)


### PR DESCRIPTION
It looks like the code for removing the links column was removed in this commit:
https://github.com/pytest-dev/pytest-html/commit/40a80d535de3e48f14e19fb86984575dd60d9daf

I have re-added it!