### PR TITLE
Change `unescape` to `decodeURI`

### DIFF
--- a/src/pytest_html/scripts/storage.js
+++ b/src/pytest_html/scripts/storage.js
@@ -30,7 +30,7 @@ const hideCategory = (categoryToHide) => {
     const settings = [...new Set(currentVisible)].filter((f) => f !== categoryToHide).join(',')
 
     url.searchParams.set('visible', settings)
-    window.history.pushState({}, null, unescape(url.href))
+    window.history.pushState({}, null, decodeURI(url.href))
 }
 
 const showCategory = (categoryToShow) => {
@@ -44,7 +44,7 @@ const showCategory = (categoryToShow) => {
     const noFilter = possibleFilters.length === settings.length || !settings.length
 
     noFilter ? url.searchParams.delete('visible') : url.searchParams.set('visible', settings.join(','))
-    window.history.pushState({}, null, unescape(url.href))
+    window.history.pushState({}, null, decodeURI(url.href))
 }
 
 const getSort = (initialSort) => {
@@ -59,7 +59,7 @@ const getSort = (initialSort) => {
 const setSort = (type) => {
     const url = new URL(window.location.href)
     url.searchParams.set('sort', type)
-    window.history.pushState({}, null, unescape(url.href))
+    window.history.pushState({}, null, decodeURI(url.href))
 }
 
 const getCollapsedCategory = (renderCollapsed) => {


### PR DESCRIPTION
This should be `decodeURI(url.href)`, otherwise if %-encoded characters are present in the file path, they will get decoded to incorrect characters, resulting in errors like:

```
report.html:719 Uncaught DOMException: Failed to execute 'pushState' on 'History': A history state object with URL
'file:///home/user/%C3%90%C2%97%C3%90%C2%B0%C3%90%C2%B3%C3%91%C2%80%C3%91%C2%83%C3%90%C2%B7%C3%90%C2%BA%C3%90%C2%B8/report_x86_work/report.html?sort=result'
cannot be created in a document with origin 'null' and URL
'file:///home/user/%D0%97%D0%B0%D0%B3%D1%80%D1%83%D0%B7%D0%BA%D0%B8/report_x86_work/report.html'.
```

if file is located in a path with non-latin characters (note the different %-encoded strings), which results in no tests being shown in the report, just the counts.

Tested by manually changing this in a generated HTML, changing here because I'm relatively confident this will work.