### PR TITLE
Give a name to the Report plugin to allow other plugins to deactivate it easily

### DIFF
--- a/src/pytest_html/plugin.py
+++ b/src/pytest_html/plugin.py
@@ -114,7 +114,7 @@ def pytest_configure(config):
             else:
                 html = Report(html_path, config, report_data, template, processed_css)
 
-            config.pluginmanager.register(html)
+            config.pluginmanager.register(html, "html_report")
 
 
 def pytest_unconfigure(config):


### PR DESCRIPTION
I have a custom plugin that runs my tests in forked processes. I run into issues when using `generate_report_on_test` because each worker generates the report.