### PR TITLE
Implement `generate_report_on_test_rate`

### DIFF
--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -21,6 +21,14 @@ ini-value:
   [pytest]
   generate_report_on_test = True
 
+If you have many tests report streaming may slow down pytest. You can limit how often
+tests generate the report using ``generate_report_on_test_rate`` ini-value:
+
+.. code-block:: ini
+
+  [pytest]
+  generate_report_on_test_rate = 1.0
+
 Creating a self-contained report
 --------------------------------
 

--- a/src/pytest_html/plugin.py
+++ b/src/pytest_html/plugin.py
@@ -79,6 +79,13 @@ def pytest_addoption(parser):
         help="the HTML report will be generated after each test "
         "instead of at the end of the run.",
     )
+    parser.addini(
+        "generate_report_on_test_rate",
+        type="float",
+        default=0.0,
+        help="limit how often the report can be generated "
+        "expects a value in seconds",
+    )
 
 
 def pytest_configure(config):


### PR DESCRIPTION
I have a big testsuite with 30k tests that are fairly cheap to run. Using `generate_report_on_test` means generating the report many times per second. It multiplies the total time my runs take by at least 5.

`generate_report_on_test_rate` allow limiting how often `_generate_report` is run.

No sure about the naming, feel free to update the PR.

