### PR TITLE
Doc: Add pyproject version of generate_report_on_test option

### DIFF
--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -14,7 +14,16 @@ Report streaming
 
 In order to stream the result, basically generating the report for each finished test
 instead of waiting until the full run is finished, you can set the ``generate_report_on_test``
-ini-value:
+value.
+
+Using `pyproject.toml` file:
+
+.. code-block:: toml
+
+  [tool.pytest.ini_options]
+  generate_report_on_test = true
+
+or using `pytest.ini` file:
 
 .. code-block:: ini
 


### PR DESCRIPTION
Hello
Here is a documentation add about about report streaming (`generate_report_on_test` key) with `pyproject.toml` file.

See https://github.com/pytest-dev/pytest-html/issues/839#issuecomment-2573610665 to understand for more informations.