### PR TITLE
Added report_path expansion method with support to string format

### DIFF
--- a/src/pytest_html/basereport.py
+++ b/src/pytest_html/basereport.py
@@ -22,7 +22,7 @@ from pytest_html import extras
 class BaseReport:
     def __init__(self, report_path, config, report_data, template, css):
         self._generated = datetime.now(tz=timezone.utc)
-        
+
         report_path_expanded = self._expand_path(report_path)
         self._report_path = (
             Path.cwd() / Path(report_path_expanded).expanduser()


### PR DESCRIPTION
The report path now can also contain parameters that get replaced when the report is being created. These parameters are:

- `%(generated_time)s`: Report generated UTC date and time, in ISO format with : replaced with -.

`report-%(generated_time)s.html` will become `report-2025-10-08T21-45-08.237134.html`
