### PR TITLE
Fix(template): Replace hardcoded "rerun" check with loop.last for comma logic

### DIFF
--- a/src/pytest_html/resources/index.jinja2
+++ b/src/pytest_html/resources/index.jinja2
@@ -83,7 +83,7 @@
           <div class="filters">
           {%- for result, values in outcomes.items() %}
             <input checked="true" class="filter" name="filter_checkbox" type="checkbox" data-test-result="{{ result }}" {{ "disabled" if values["value"] == 0 }}>
-            <span class="{{ result }}">{{ values["value"] }} {{ values["label"] }}{{ "," if result != "rerun" }}</span>
+            <span class="{{ result }}">{{ values["value"] }} {{ values["label"] }}{{ "," if not loop.last }}</span>
           {%- endfor %}
           </div>
           <div class="collapse">


### PR DESCRIPTION
Replace hardcoded "rerun" check with Jinja2 loop.last for comma logic

The comma condition in the outcomes loop was hardcoded to check `result != "rerun"`, which breaks since #836 added "retried" after "rerun" in the outcomes dict. Using Jinja2's `loop.last` is the correct, order-independent approach.