### PR TITLE
Escape HTML in the test id column

### DIFF
--- a/src/pytest_html/basereport.py
+++ b/src/pytest_html/basereport.py
@@ -284,7 +284,7 @@ class BaseReport:
         ]
         cells = [
             f'<td class="col-result">{outcome}</td>',
-            f'<td class="col-testId">{test_id}</td>',
+            f'<td class="col-testId">{escape(test_id)}</td>',
             f'<td class="col-duration">{formatted_duration}</td>',
             f'<td class="col-links">{_process_links(links)}</td>',
         ]

--- a/testing/test_unit.py
+++ b/testing/test_unit.py
@@ -1,9 +1,11 @@
 import importlib.resources
+import json
 import sys
 from pathlib import Path
 
 import pytest
 from assertpy import assert_that
+from bs4 import BeautifulSoup
 
 pytest_plugins = ("pytester",)
 
@@ -146,3 +148,29 @@ def test_custom_css_selfcontained(pytester, css_file_path, expandvar):
     with open(pytester.path / "report.html") as f:
         html = f.read()
         assert_that(html).contains("* " + str(css_file_path)).contains("* two.css")
+
+
+def test_html_in_test_id_is_escaped(pytester):
+    pytester.makepyfile(
+        """
+        import pytest
+
+
+        @pytest.mark.parametrize("value", ["<b>pwned</b>"])
+        def test_id_escaping(value):
+            pass
+    """
+    )
+    result = run(pytester)
+    result.assert_outcomes(passed=1)
+
+    html = (pytester.path / "report.html").read_text(encoding="utf-8")
+    blob = BeautifulSoup(html, "html.parser").find(id="data-container")["data-jsonblob"]
+    tests = json.loads(blob)["tests"]
+    nodeid = next(key for key in tests if "test_id_escaping" in key)
+    row = tests[nodeid][0]["resultsTableRow"]
+    test_id_cell = next(cell for cell in row if "col-testId" in cell)
+
+    assert_that(test_id_cell).does_not_contain("<b>pwned</b>").contains(
+        "&lt;b&gt;pwned&lt;/b&gt;"
+    )


### PR DESCRIPTION
The parametrized test id (report.nodeid) is interpolated into the results table cell in basereport.py without escaping:

    f'<td class="col-testId">{test_id}</td>'

When a test parameter contains HTML, the value reaches the report data verbatim and the renderer inserts it with innerHTML, so it shows as live markup instead of text. Reproduction from #1024 is a parametrized value such as a span tag with inline style.

Fix: escape the test id, the same way the log cell already is (escape on report.longreprtext). One line.

Test: added test_html_in_test_id_is_escaped in testing/test_unit.py. It runs a session with an HTML test id, reads the report data blob, and asserts the test id cell contains the escaped form rather than the raw tags.

Closes #1024