### PR TITLE
docs: fix typo Cascasding→Cascading and update deprecated pypi.python.org URLs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,13 +1,13 @@
 pytest-html
 ===========
 
-pytest-html is a plugin for `pytest <http://pytest.org>`_ that generates a HTML report for test results.
+pytest-html is a plugin for `pytest <https://pytest.org>`_ that generates a HTML report for test results.
 
 .. image:: https://img.shields.io/badge/license-MPL%202.0-blue.svg
    :target: https://github.com/pytest-dev/pytest-html/blob/master/LICENSE
    :alt: License
 .. image:: https://img.shields.io/pypi/v/pytest-html.svg
-   :target: https://pypi.python.org/pypi/pytest-html/
+   :target: https://pypi.org/project/pytest-html/
    :alt: PyPI
 .. image:: https://img.shields.io/conda/vn/conda-forge/pytest-html.svg
    :target: https://anaconda.org/conda-forge/pytest-html
@@ -27,8 +27,8 @@ Resources
 
 - `Documentation <https://pytest-html.readthedocs.io/en/latest/>`_
 - `Release Notes <https://pytest-html.readthedocs.io/en/latest/changelog.html>`_
-- `Issue Tracker <http://github.com/pytest-dev/pytest-html/issues>`_
-- `Code <http://github.com/pytest-dev/pytest-html/>`_
+- `Issue Tracker <https://github.com/pytest-dev/pytest-html/issues>`_
+- `Code <https://github.com/pytest-dev/pytest-html/>`_
 
 Contributing
 ------------

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -54,7 +54,7 @@ Enhancing reports
 Appearance
 ~~~~~~~~~~
 
-Custom CSS (Cascasding Style Sheets) can be passed on the command line using
+Custom CSS (Cascading Style Sheets) can be passed on the command line using
 the :code:`--css` option. These will be applied in the order specified, and can
 be used to change the appearance of the report.
 
@@ -350,9 +350,9 @@ Below is an example of a :code:`conftest.py` file setting :code:`pytest_html_dur
 **NOTE**: The formatting of the total duration is not affected by this hook.
 
 .. _@pytest.hookimpl(tryfirst=True): https://docs.pytest.org/en/stable/writing_plugins.html#hook-function-ordering-call-example
-.. _ansi2html: https://pypi.python.org/pypi/ansi2html/
+.. _ansi2html: https://pypi.org/project/ansi2html/
 .. _Content Security Policy (CSP): https://developer.mozilla.org/docs/Web/Security/CSP/
 .. _JSON: https://json.org/
-.. _pytest-metadata: https://pypi.python.org/pypi/pytest-metadata/
-.. _pytest-xdist: https://pypi.python.org/pypi/pytest-xdist/
+.. _pytest-metadata: https://pypi.org/project/pytest-metadata/
+.. _pytest-xdist: https://pypi.org/project/pytest-xdist/
 .. _time.strftime: https://docs.python.org/3/library/time.html#time.strftime


### PR DESCRIPTION
## What

Fix a typo and replace deprecated `pypi.python.org` URLs across two documentation files.

### Changes

**`docs/user_guide.rst`**
- Fix typo: `Cascasding Style Sheets` → `Cascading Style Sheets` (Appearance section)
- Replace `https://pypi.python.org/pypi/ansi2html/` → `https://pypi.org/project/ansi2html/`
- Replace `https://pypi.python.org/pypi/pytest-metadata/` → `https://pypi.org/project/pytest-metadata/`
- Replace `https://pypi.python.org/pypi/pytest-xdist/` → `https://pypi.org/project/pytest-xdist/`

**`README.rst`**
- Replace `https://pypi.python.org/pypi/pytest-html/` → `https://pypi.org/project/pytest-html/` (PyPI badge target)
- Replace `http://pytest.org` → `https://pytest.org`
- Replace `http://github.com/...` → `https://github.com/...` (Issue Tracker and Code links)

## Why

- `pypi.python.org` redirects to `pypi.org` but the canonical URL has been `pypi.org` since 2018 — updating avoids an unnecessary redirect and keeps links current.
- The HTTP links should use HTTPS for security best practice.
- The typo is harmless but confusing for readers.

## Verification

Manual review of the RST files; no functional code changed.
