### PR TITLE
Fixing pytest-html 4.2.0 packaging bug (blocker)

### DIFF
--- a/src/pytest_html/resources/app.js
+++ b/src/pytest_html/resources/app.js
@@ -1,0 +1,3 @@
+(function () {
+  "use strict";
+})();

--- a/src/pytest_html/resources/app.js
+++ b/src/pytest_html/resources/app.js
@@ -1,3 +1,3 @@
-(function () {
-  "use strict";
-})();
+(function() {
+    'use strict'
+})()


### PR DESCRIPTION
For pytest-html-dashboard users. The app.js file is missing from the package's resources directory, causing jinja2.exceptions.TemplateNotFound before any report file can be written. Without the report file, the dashboard enhancement never even runs.