### PR TITLE
ci: Add Python 3.14 and 3.15 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -83,11 +83,12 @@ jobs:
   test_unit:
     name: ${{ matrix.os }} - ${{ matrix.python-version }} - unit
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.experimental || false }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "pypy3.9"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.15", "pypy3.9"]
         include:
           - os: ubuntu-latest
             python-version: "3.10"
@@ -102,6 +103,10 @@ jobs:
           - os: macos-latest
             python-version: 3.13
             tox-env: devel
+
+          # Python 3.15 is not released yet; allow it to fail without blocking.
+          - python-version: "3.15"
+            experimental: true
 
     steps:
       - name: Set newline behavior
@@ -118,6 +123,7 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
 
       - name: Ensure latest pip
         run: python -m pip install --upgrade pip
@@ -160,15 +166,19 @@ jobs:
   test_integration:
     name: ubuntu - ${{ matrix.python-version }} - integration
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental || false }}
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "pypy3.9"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.15", "pypy3.9"]
         include:
           - python-version: "3.10"
             with-coverage: true
           - python-version: 3.13
             tox-env: devel
+          # Python 3.15 is not released yet; allow it to fail without blocking.
+          - python-version: "3.15"
+            experimental: true
 
     steps:
       - name: Set newline behavior
@@ -188,6 +198,7 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
 
       - name: Ensure latest pip
         run: python -m pip install --upgrade pip
@@ -230,13 +241,17 @@ jobs:
   test_e2e:
     name: ubuntu - ${{ matrix.python-version }} - e2e
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental || false }}
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "pypy3.9"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.15", "pypy3.9"]
         include:
           - python-version: 3.13
             tox-env: devel
+          # Python 3.15 is not released yet; allow it to fail without blocking.
+          - python-version: "3.15"
+            experimental: true
 
     steps:
       - name: Set newline behavior
@@ -256,6 +271,7 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
 
       - name: Ensure latest pip
         run: python -m pip install --upgrade pip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
+  "Programming Language :: Python :: 3.15",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
   "Topic :: Software Development :: Quality Assurance",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
-  "Programming Language :: Python :: 3.15",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
   "Topic :: Software Development :: Quality Assurance",

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = {3.9, 3.10, 3.10-cov, 3.11, 3.12, 3.13, pypy3.9}, docs, linting
+envlist = {3.9, 3.10, 3.10-cov, 3.11, 3.12, 3.13, 3.14, 3.15, pypy3.9}, docs, linting
 isolated_build = True
 
 [testenv]


### PR DESCRIPTION
- Add 3.15 trove classifier (3.14 already present)
- Add 3.14 and 3.15 to tox envlist
- Add 3.14 and 3.15 to unit, integration and e2e CI matrices
- Enable allow-prereleases on setup-python so 3.15 pre-releases install
- Mark 3.15 experimental (continue-on-error) since it is not yet released, so its failures do not block PRs